### PR TITLE
Correct indenting on docker volume

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,5 +7,5 @@ services:
       - POSTGRES_DB=${DATABASE_NAME}
     ports:
       - "5432:5432"
-      volumes:
+    volumes:
       - ./db-volume:/var/lib/postgresql/data


### PR DESCRIPTION
The code suggestion for the volume section in the compose.yaml had too much spacing. This commit applies the correct spacing.