### PR TITLE
create multipolygon spatial types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
         "@types/express": "^4.17.17",
+        "@types/geojson": "^7946.0.12",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
         "@types/supertest": "^2.0.12",
@@ -2392,6 +2393,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.12",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.12.tgz",
+      "integrity": "sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
+    "@types/geojson": "^7946.0.12",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",

--- a/src/mikro-orm-pgis/geography/MultiPolygon.ts
+++ b/src/mikro-orm-pgis/geography/MultiPolygon.ts
@@ -1,0 +1,16 @@
+import { Type } from "@mikro-orm/core";
+import { MultiPolygon } from "geojson";
+import { SimpleFeature } from "..";
+
+export class MultiPolygonGeogType extends Type<MultiPolygon, string> {
+  constructor(srid = 4326) {
+    super();
+    this.srid = srid;
+  }
+
+  srid: number;
+
+  getColumnType(): string {
+    return `geography(${SimpleFeature.MultiPolygon}, ${this.srid})`;
+  }
+}

--- a/src/mikro-orm-pgis/geography/index.ts
+++ b/src/mikro-orm-pgis/geography/index.ts
@@ -1,0 +1,1 @@
+export { MultiPolygonGeogType } from "./MultiPolygon";

--- a/src/mikro-orm-pgis/geometry/MultiPolygon.ts
+++ b/src/mikro-orm-pgis/geometry/MultiPolygon.ts
@@ -1,0 +1,16 @@
+import { Type } from "@mikro-orm/core";
+import { MultiPolygon } from "geojson";
+import { SimpleFeature } from "..";
+
+export class MultiPolygonGeomType extends Type<MultiPolygon, string> {
+  constructor(srid = 3857) {
+    super();
+    this.srid = srid;
+  }
+
+  srid: number;
+
+  getColumnType(): string {
+    return `geometry(${SimpleFeature.MultiPolygon}, ${this.srid})`;
+  }
+}

--- a/src/mikro-orm-pgis/geometry/index.ts
+++ b/src/mikro-orm-pgis/geometry/index.ts
@@ -1,0 +1,1 @@
+export { MultiPolygonGeomType } from "./MultiPolygon";

--- a/src/mikro-orm-pgis/index.ts
+++ b/src/mikro-orm-pgis/index.ts
@@ -1,0 +1,4 @@
+export { SimpleFeature } from "./types";
+
+export * from "./geography";
+export * from "./geometry";

--- a/src/mikro-orm-pgis/types.ts
+++ b/src/mikro-orm-pgis/types.ts
@@ -1,0 +1,3 @@
+export enum SimpleFeature {
+  MultiPolygon = "MultiPolygon",
+}


### PR DESCRIPTION
# Description
- Create multipolygon geometry and geography types

# Example
The [tax-lot schema file](https://github.com/NYCPlanning/ae-zoning-api/compare/main...multipolygon-example#diff-740efd93aebb3c22820e9531d82de6827a5723a1887d102636b7bfc25d4d5ecd) on the the [multipolygon-example branch](https://github.com/NYCPlanning/ae-zoning-api/tree/multipolygon-example) shows the [migration with spatial types](https://github.com/NYCPlanning/ae-zoning-api/compare/main...multipolygon-example#diff-bc32c8db8524f0aafbde6bdbd6fda4e918f35fb2c32387432607e1cc2f208134R6) that will be created when using this type

# Tickets
- closes #10 