### PR TITLE
Add boroughs endpoint openapi

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,12 +5,16 @@ info:
     An API for serving data related to the zoning of New York City.
   version: 0.1.0
 servers:
-  - url: https://zoning-api.planningdigital.com
+  - url: https://zoning.planningdigital.com/api
+tags:
+  - name: Boroughs
 paths:
   /boroughs:
-    get:
-      summary: Returns a list of boroughs.
+    get: 
+      summary: List boroughs
       operationId: getBoroughs
+      tags:
+      - Boroughs
       responses:
         '200':
           description: An array of borough objects.
@@ -40,3 +44,7 @@ components:
           minLength: 2
           maxLength: 2
           example: MN
+      required:
+        - id
+        - title
+        - abbr

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -40,7 +40,7 @@ components:
           example: Manhattan
         abbr:
           type: string
-          description: The two character abbrevation for the borough.
+          description: The two character abbreviation for the borough.
           minLength: 2
           maxLength: 2
           example: MN

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,7 +33,7 @@ components:
           type: string
           description: A single character numeric string containing the common number used to refer to the borough. Possible values are 1-5.
           pattern: \b[1-9]\b
-          example: 2
+          example: 1
         title:
           type: string
           description: The full name of the borough.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Zoning API
+  description: |-
+    An API for serving data related to the zoning of New York City.
+  version: 0.1.0
+servers:
+  - url: https://zoning-api.planningdigital.com
+paths:
+  /boroughs:
+    get:
+      summary: Returns a list of boroughs.
+      operationId: getBoroughs
+      responses:
+        '200':
+          description: An array of borough objects.
+          content:
+            application/json:
+              schema: 
+                type: array
+                items: 
+                  $ref: '#/components/schemas/Borough'
+components:
+  schemas:
+    Borough:
+      type: object
+      properties:
+        id:
+          type: string
+          description: A single character numeric string containing the common number used to refer to the borough. Possible values are 1-5.
+          pattern: \b[1-9]\b
+          example: 2
+        title:
+          type: string
+          description: The full name of the borough.
+          example: Manhattan
+        abbr:
+          type: string
+          description: The two character abbrevation for the borough.
+          minLength: 2
+          maxLength: 2
+          example: MN


### PR DESCRIPTION
This PR adds an [OpenAPI](https://www.openapis.org/) compliant API description file. In addition to basic info about the API itself, it documents a `/boroughs` endpoint and the schema for the data returned by that endpoint. For the schema's properties, I assigned example values, bounds, and which are required. Note that this configuration specifies that all three properties are both _required_ (meaning they cannot be undefined) and _non-nullable_ (meaning they will always return a value of their specified type and never a literal `null`).

We don't have any tooling set up for this repo to generate and serve docs based on this OpenAPI file ([_yet_](https://github.com/NYCPlanning/ae-zoning-api/issues/15)) but I previewed it in VSCode using [this extension](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi) and it does render successfully:
<img width="1362" alt="image" src="https://github.com/NYCPlanning/ae-zoning-api/assets/9055367/0e733e8f-04b6-45eb-b3c2-0db597fc60a5">
