### PR TITLE
6/add zoning district tables to api

### DIFF
--- a/src/migrations/.snapshot-zoning.json
+++ b/src/migrations/.snapshot-zoning.json
@@ -211,6 +211,196 @@
           "updateRule": "cascade"
         }
       }
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "gen_random_uuid()",
+          "mappedType": "uuid"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(MultiPolygon, 4326)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "unknown"
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(MultiPolygon, 2263)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "unknown"
+        }
+      },
+      "name": "zoning_district",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "zoning_district_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "enumItems": [
+            "Residential",
+            "Commercial",
+            "Manufacturing"
+          ],
+          "mappedType": "enum"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "unknown"
+        }
+      },
+      "name": "zoning_district_class",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "zoning_district_class_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {}
+    },
+    {
+      "columns": {
+        "zoning_district_id": {
+          "name": "zoning_district_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "zoning_district_class_id": {
+          "name": "zoning_district_class_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        }
+      },
+      "name": "zoning_district_classes",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "zoning_district_classes_pkey",
+          "columnNames": [
+            "zoning_district_id",
+            "zoning_district_class_id"
+          ],
+          "composite": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "zoning_district_classes_zoning_district_id_foreign": {
+          "constraintName": "zoning_district_classes_zoning_district_id_foreign",
+          "columnNames": [
+            "zoning_district_id"
+          ],
+          "localTableName": "public.zoning_district_classes",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.zoning_district",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "zoning_district_classes_zoning_district_class_id_foreign": {
+          "constraintName": "zoning_district_classes_zoning_district_class_id_foreign",
+          "columnNames": [
+            "zoning_district_class_id"
+          ],
+          "localTableName": "public.zoning_district_classes",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.zoning_district_class",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      }
     }
   ]
 }

--- a/src/migrations/Migration20231102185908.ts
+++ b/src/migrations/Migration20231102185908.ts
@@ -1,0 +1,40 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20231102185908 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "zoning_district" ("id" uuid not null default gen_random_uuid(), "label" text not null, "wgs84" geography(MultiPolygon, 4326) not null, "li_ft" geometry(MultiPolygon, 2263) not null, constraint "zoning_district_pkey" primary key ("id"));',
+    );
+
+    this.addSql(
+      'create table "zoning_district_class" ("id" text not null, "category" text check ("category" in (\'Residential\', \'Commercial\', \'Manufacturing\')) not null, "description" text not null, "url" text null, "color" char(9) not null, constraint "zoning_district_class_pkey" primary key ("id"));',
+    );
+
+    this.addSql(
+      'create table "zoning_district_classes" ("zoning_district_id" uuid not null, "zoning_district_class_id" text not null, constraint "zoning_district_classes_pkey" primary key ("zoning_district_id", "zoning_district_class_id"));',
+    );
+
+    this.addSql(
+      'alter table "zoning_district_classes" add constraint "zoning_district_classes_zoning_district_id_foreign" foreign key ("zoning_district_id") references "zoning_district" ("id") on update cascade on delete cascade;',
+    );
+    this.addSql(
+      'alter table "zoning_district_classes" add constraint "zoning_district_classes_zoning_district_class_id_foreign" foreign key ("zoning_district_class_id") references "zoning_district_class" ("id") on update cascade on delete cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "zoning_district_classes" drop constraint "zoning_district_classes_zoning_district_id_foreign";',
+    );
+
+    this.addSql(
+      'alter table "zoning_district_classes" drop constraint "zoning_district_classes_zoning_district_class_id_foreign";',
+    );
+
+    this.addSql('drop table if exists "zoning_district" cascade;');
+
+    this.addSql('drop table if exists "zoning_district_class" cascade;');
+
+    this.addSql('drop table if exists "zoning_district_classes" cascade;');
+  }
+}

--- a/src/zoning-district-class/zoning-district-class.entity.ts
+++ b/src/zoning-district-class/zoning-district-class.entity.ts
@@ -11,6 +11,9 @@ export class ZoningDistrictClass {
   @Property({ type: types.text })
   description: string;
 
+  @Property({ type: types.text, nullable: true })
+  url: string;
+
   @Property({ columnType: "char(9)" })
   color: string;
 
@@ -18,11 +21,13 @@ export class ZoningDistrictClass {
     id: string,
     category: ZoningDistrictClassCategory,
     description: string,
+    url: string,
     color: string,
   ) {
     this.id = id;
     this.category = category;
     this.description = description;
+    this.url = url;
     this.color = color;
   }
 }

--- a/src/zoning-district-class/zoning-district-class.entity.ts
+++ b/src/zoning-district-class/zoning-district-class.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryKey, Property, types, Enum } from "@mikro-orm/core";
+
+@Entity()
+export class ZoningDistrictClass {
+  @PrimaryKey({ type: types.text })
+  id: string;
+
+  @Enum(() => ZoningDistrictClassCategory)
+  category: ZoningDistrictClassCategory;
+
+  @Property({ type: types.text })
+  description: string;
+
+  @Property({ columnType: "char(9)" })
+  color: string;
+
+  constructor(
+    id: string,
+    category: ZoningDistrictClassCategory,
+    description: string,
+    color: string,
+  ) {
+    this.id = id;
+    this.category = category;
+    this.description = description;
+    this.color = color;
+  }
+}
+
+export enum ZoningDistrictClassCategory {
+  Residential = "Residential",
+  Commercial = "Commercial",
+  Manufacturing = "Manufacturing",
+}

--- a/src/zoning-district/zoning-district.entity.ts
+++ b/src/zoning-district/zoning-district.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryKey, Property, types, UuidType } from "@mikro-orm/core";
+import { MultiPolygonGeogType, MultiPolygonGeomType } from "../mikro-orm-pgis";
+import { MultiPolygon } from "geojson";
+
+@Entity()
+export class ZoningDistrict {
+  @PrimaryKey({ type: UuidType })
+  id: string;
+
+  @Property({ type: types.text })
+  label: string;
+
+  @Property({ type: new MultiPolygonGeogType(4326) })
+  wgs84: MultiPolygon;
+
+  @Property({ type: new MultiPolygonGeomType(2263) })
+  liFt: MultiPolygon;
+
+  constructor(
+    id: string,
+    label: string,
+    wgs84: MultiPolygon,
+    liFt: MultiPolygon,
+  ) {
+    this.id = id;
+    this.label = label;
+    this.wgs84 = wgs84;
+    this.liFt = liFt;
+  }
+}

--- a/src/zoning-district/zoning-district.entity.ts
+++ b/src/zoning-district/zoning-district.entity.ts
@@ -1,10 +1,18 @@
-import { Entity, PrimaryKey, Property, types, UuidType } from "@mikro-orm/core";
+import {
+  Entity,
+  PrimaryKey,
+  Property,
+  types,
+  ManyToMany,
+  Collection,
+} from "@mikro-orm/core";
 import { MultiPolygonGeogType, MultiPolygonGeomType } from "../mikro-orm-pgis";
 import { MultiPolygon } from "geojson";
+import { ZoningDistrictClass } from "../zoning-district-class/zoning-district-class.entity";
 
 @Entity()
 export class ZoningDistrict {
-  @PrimaryKey({ type: UuidType })
+  @PrimaryKey({ type: types.uuid, defaultRaw: "gen_random_uuid()" })
   id: string;
 
   @Property({ type: types.text })
@@ -16,13 +24,11 @@ export class ZoningDistrict {
   @Property({ type: new MultiPolygonGeomType(2263) })
   liFt: MultiPolygon;
 
-  constructor(
-    id: string,
-    label: string,
-    wgs84: MultiPolygon,
-    liFt: MultiPolygon,
-  ) {
-    this.id = id;
+  @ManyToMany(() => ZoningDistrictClass)
+  classes: Collection<ZoningDistrictClass> =
+    new Collection<ZoningDistrictClass>(this);
+
+  constructor(label: string, wgs84: MultiPolygon, liFt: MultiPolygon) {
     this.label = label;
     this.wgs84 = wgs84;
     this.liFt = liFt;


### PR DESCRIPTION
# Description
- Add Zoning District db tables schema to Zoning API
- Builds on the commits for the tax lots and multipolygon tickets


## Tickets 
- closes #6 
