### PR TITLE
28/implement zd endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { join } from "path";
 import { BoroughModule } from "./borough/borough.module";
 import { LandUseModule } from "./land-use/land-use.module";
 import { TaxLotModule } from "./tax-lot/tax-lot.module";
+import { ZoningDistrictModule } from "./zoning-district/zoning-district.module";
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { TaxLotModule } from "./tax-lot/tax-lot.module";
     BoroughModule,
     LandUseModule,
     TaxLotModule,
+    ZoningDistrictModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/zoning-district/zoning-district.controller.ts
+++ b/src/zoning-district/zoning-district.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { ZoningDistrictService } from "./zoning-district.service";
+
+@Controller("zoning-districts")
+export class ZoningDistrictController {
+  constructor(private readonly zoningDistrictService: ZoningDistrictService) {}
+
+  @Get("/:id")
+  async findById(@Param() params: { id: string }) {
+    return this.zoningDistrictService.findById(params.id);
+  }
+}

--- a/src/zoning-district/zoning-district.module.ts
+++ b/src/zoning-district/zoning-district.module.ts
@@ -1,0 +1,13 @@
+import { MikroOrmModule } from "@mikro-orm/nestjs";
+import { Module } from "@nestjs/common";
+import { ZoningDistrict } from "./zoning-district.entity";
+import { ZoningDistrictService } from "./zoning-district.service";
+import { ZoningDistrictController } from "./zoning-district.controller";
+
+@Module({
+  imports: [MikroOrmModule.forFeature({ entities: [ZoningDistrict] })],
+  exports: [ZoningDistrictService],
+  providers: [ZoningDistrictService],
+  controllers: [ZoningDistrictController],
+})
+export class ZoningDistrictModule {}

--- a/src/zoning-district/zoning-district.repository.ts
+++ b/src/zoning-district/zoning-district.repository.ts
@@ -1,0 +1,4 @@
+import { EntityRepository } from "@mikro-orm/postgresql";
+import { ZoningDistrict } from "./zoning-district.entity";
+
+export class ZoningDistrictRepository extends EntityRepository<ZoningDistrict> {}

--- a/src/zoning-district/zoning-district.service.ts
+++ b/src/zoning-district/zoning-district.service.ts
@@ -1,0 +1,18 @@
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { Injectable } from "@nestjs/common";
+import { ZoningDistrict } from "./zoning-district.entity";
+import { ZoningDistrictRepository } from "./zoning-district.repository";
+
+@Injectable()
+export class ZoningDistrictService {
+  constructor(
+    @InjectRepository(ZoningDistrict)
+    private readonly zoningDistrictRepository: ZoningDistrictRepository,
+  ) {}
+
+  async findById(id: string): Promise<ZoningDistrict | null> {
+    return this.zoningDistrictRepository.findOne(id, {
+      fields: ["id", "label"],
+    });
+  }
+}


### PR DESCRIPTION
# Description
Implements the `zoning-districts/<uuid>` endpoint.

## Tech debt
Returns `null` with a `200` status when no zoning district has the requested ID. This is should be a `404`. However, this should also be outlined in the OpenAPI documentation first. 

Fortunately, it does not exclude the `happy path` (when a zoning district is found). In the interest of time, this PR moves forward with the happy path and notes the need for future work.

## Tickets
closes #28  