### PR TITLE
Revert 45 secure migration connection

### DIFF
--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -16,5 +16,4 @@ export default defineConfig({
   // @ts-expect-error nestjs adapter option
   registerRequestContext: false,
   extensions: [Migrator],
-  driverOptions: { connection: { ssl: { rejectUnauthorized: false } } },
 });

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -17,7 +17,4 @@ export default defineConfig({
   registerRequestContext: false,
   extensions: [Migrator],
   driverOptions: { connection: { ssl: { rejectUnauthorized: false } } },
-  migrations: {
-    disableForeignKeys: false,
-  },
 });


### PR DESCRIPTION
These changes are causing issues with local databases, which do not support secure connections.

They also could be made more robust by only allowing connections with 3rd party-verified ssl certifictates