### PR TITLE
118/e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/serve-static": "^4.0.0",
         "drizzle-orm": "^0.29.0",
-        "drizzle-zod": "^0.5.1",
         "joi": "^17.11.0",
         "pg": "^8.11.3",
         "reflect-metadata": "^0.1.13",
@@ -23,6 +22,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@anatine/zod-mock": "^3.13.3",
+        "@faker-js/faker": "^8.3.1",
         "@kubb/cli": "^1.14.9",
         "@kubb/core": "^1.14.9",
         "@kubb/swagger": "^1.14.9",
@@ -46,6 +47,7 @@
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "faker-js": "^1.0.0",
         "geojson": "npm:empty-npm-package@^1.0.0",
         "husky": "^8.0.3",
         "jest": "^29.5.0",
@@ -80,6 +82,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anatine/zod-mock": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@anatine/zod-mock/-/zod-mock-3.13.3.tgz",
+      "integrity": "sha512-AN+0YEFE7s6BpuALQHhEoVmJmD+0gPnf4Fehc6oE5NHbM3X2ZD5fW5M6vvot29NWUB6nxvj0gu+BPQ9cVnxALw==",
+      "dev": true,
+      "dependencies": {
+        "randexp": "^0.5.3"
+      },
+      "peerDependencies": {
+        "@faker-js/faker": "^7.0.0 || ^8.0.0",
+        "zod": "^3.21.4"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -2188,6 +2203,22 @@
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.3.1.tgz",
+      "integrity": "sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.0",
@@ -6363,6 +6394,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dreamopt": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
@@ -6550,15 +6590,6 @@
         "sqlite3": {
           "optional": true
         }
-      }
-    },
-    "node_modules/drizzle-zod": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/drizzle-zod/-/drizzle-zod-0.5.1.tgz",
-      "integrity": "sha512-C/8bvzUH/zSnVfwdSibOgFjLhtDtbKYmkbPbUCq46QZyZCH6kODIMSOgZ8R7rVjoI+tCj3k06MRJMDqsIeoS4A==",
-      "peerDependencies": {
-        "drizzle-orm": ">=0.23.13",
-        "zod": "*"
       }
     },
     "node_modules/eastasianwidth": {
@@ -7319,6 +7350,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/faker-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/faker-js/-/faker-js-1.0.0.tgz",
+      "integrity": "sha512-kaToadbN63LWhHjl69pqG+YHlxAK0aZAPhQDUpVP7v7+RG//ZpK0OzXjCwaAQq98awOii0WSHxtJmIz0X7/UqQ==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -12106,6 +12143,19 @@
         }
       ]
     },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "dev": true,
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12456,6 +12506,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/serve-static": "^4.0.0",
     "drizzle-orm": "^0.29.0",
-    "drizzle-zod": "^0.5.1",
     "joi": "^17.11.0",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
@@ -41,6 +40,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@anatine/zod-mock": "^3.13.3",
+    "@faker-js/faker": "^8.3.1",
     "@kubb/cli": "^1.14.9",
     "@kubb/core": "^1.14.9",
     "@kubb/swagger": "^1.14.9",
@@ -64,6 +65,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "faker-js": "^1.0.0",
     "geojson": "npm:empty-npm-package@^1.0.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
@@ -84,6 +86,9 @@
       "ts"
     ],
     "rootDir": "src",
+    "modulePaths": [
+      "<rootDir>/../"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/src/schema/borough.ts
+++ b/src/schema/borough.ts
@@ -1,5 +1,4 @@
 import { char, pgTable, text } from "drizzle-orm/pg-core";
-import { createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 
 export const borough = pgTable("borough", {
@@ -8,6 +7,10 @@ export const borough = pgTable("borough", {
   abbr: text("abbr").notNull(),
 });
 
-export const selectBoroughSchema = createSelectSchema(borough);
+export const boroughEntitySchema = z.object({
+  id: z.string().regex(/^[0-9]$/),
+  title: z.string(),
+  abbr: z.string().length(2),
+});
 
-export type SelectBorough = z.infer<typeof selectBoroughSchema>;
+export type BoroughEntity = z.infer<typeof boroughEntitySchema>;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,6 +1,6 @@
-export { borough } from "./borough";
+export { borough, boroughEntitySchema } from "./borough";
 export { taxLot, taxLotRelations } from "./tax-lot";
-export { landUse } from "./land-use";
+export { landUse, landUseEntitySchema } from "./land-use";
 export { zoningDistrict } from "./zoning-district";
 export { zoningDistrictClass, categoryEnum } from "./zoning-district-class";
 export { zoningDistrictZoningDistrictClass } from "./zoning-district-zoning-district-class";

--- a/src/schema/land-use.ts
+++ b/src/schema/land-use.ts
@@ -1,5 +1,4 @@
 import { char, pgTable, text } from "drizzle-orm/pg-core";
-import { createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 
 export const landUse = pgTable("land_use", {
@@ -8,6 +7,10 @@ export const landUse = pgTable("land_use", {
   color: char("color", { length: 9 }).notNull(),
 });
 
-export const selectLandUseSchema = createSelectSchema(landUse);
+export const landUseEntitySchema = z.object({
+  id: z.string().length(2),
+  description: z.string(),
+  color: z.string().regex(/^#([A-Fa-f0-9]{8})$/),
+});
 
-export type SelectLandUse = z.infer<typeof selectLandUseSchema>;
+export type LandUseEntity = z.infer<typeof landUseEntitySchema>;

--- a/src/schema/tax-lot.ts
+++ b/src/schema/tax-lot.ts
@@ -2,10 +2,6 @@ import { char, pgTable, text } from "drizzle-orm/pg-core";
 import { borough, landUse } from "../schema";
 import { multiPolygonGeog, multiPolygonGeom } from "../drizzle-pgis";
 import { relations } from "drizzle-orm";
-import { createSelectSchema } from "drizzle-zod";
-import { z } from "zod";
-import { SelectLandUse } from "./land-use";
-import { SelectBorough } from "./borough";
 
 export const taxLot = pgTable("tax_lot", {
   bbl: char("bbl", { length: 10 }).primaryKey(),
@@ -30,19 +26,3 @@ export const taxLotRelations = relations(taxLot, ({ one }) => ({
     references: [landUse.id],
   }),
 }));
-
-export const selectTaxLotSchema = createSelectSchema(taxLot);
-
-export type SelectTaxLot = z.infer<typeof selectTaxLotSchema>;
-
-export type SelectTaxLotNested = Pick<
-  SelectTaxLot,
-  "address" | "bbl" | "block" | "lot"
-> & {
-  borough: SelectBorough | null;
-  landUse: SelectLandUse | null;
-};
-
-export type SelectTaxLotSpatial = SelectTaxLotNested & {
-  geometry: string;
-};

--- a/src/schema/zoning-district-class.ts
+++ b/src/schema/zoning-district-class.ts
@@ -1,6 +1,4 @@
 import { char, pgEnum, pgTable, text } from "drizzle-orm/pg-core";
-import { createSelectSchema } from "drizzle-zod";
-import { z } from "zod";
 
 export const categoryEnum = pgEnum("category", [
   "Residential",
@@ -15,10 +13,3 @@ export const zoningDistrictClass = pgTable("zoning_district_class", {
   url: text("url"),
   color: char("color", { length: 9 }).notNull(),
 });
-
-export const selectZoningDistrictClassSchema =
-  createSelectSchema(zoningDistrictClass);
-
-export type SelectZoningDistrictClass = z.infer<
-  typeof selectZoningDistrictClassSchema
->;

--- a/src/schema/zoning-district.ts
+++ b/src/schema/zoning-district.ts
@@ -1,7 +1,5 @@
 import { pgTable, text, uuid } from "drizzle-orm/pg-core";
 import { multiPolygonGeog, multiPolygonGeom } from "../drizzle-pgis";
-import { createSelectSchema } from "drizzle-zod";
-import { z } from "zod";
 
 export const zoningDistrict = pgTable("zoning_district", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -9,7 +7,3 @@ export const zoningDistrict = pgTable("zoning_district", {
   wgs84: multiPolygonGeog("wgs84", 4326).notNull(),
   liFt: multiPolygonGeom("li_ft", 2263).notNull(),
 });
-
-export const selectZoningDistrictSchema = createSelectSchema(zoningDistrict);
-
-export type SelectZoningDistrict = z.infer<typeof selectZoningDistrictSchema>;

--- a/src/tax-lot/tax-lot.controller.ts
+++ b/src/tax-lot/tax-lot.controller.ts
@@ -1,16 +1,13 @@
 import {
   Controller,
   Get,
-  Inject,
   Injectable,
   Param,
   Redirect,
   UseFilters,
   UsePipes,
 } from "@nestjs/common";
-import { ConfigType } from "@nestjs/config";
 import { TaxLotService } from "./tax-lot.service";
-import { StorageConfig } from "src/config";
 import { ZodValidationPipe } from "src/pipes/zod-validation-pipe";
 import {
   getTaxLotByBblPathParamsSchema,
@@ -36,11 +33,7 @@ import {
 )
 @Controller("tax-lots")
 export class TaxLotController {
-  constructor(
-    private readonly taxLotService: TaxLotService,
-    @Inject(StorageConfig.KEY)
-    private storageConfig: ConfigType<typeof StorageConfig>,
-  ) {}
+  constructor(private readonly taxLotService: TaxLotService) {}
 
   @Get("/:bbl")
   @UsePipes(new ZodValidationPipe(getTaxLotByBblPathParamsSchema))
@@ -78,9 +71,9 @@ export class TaxLotController {
 
   @Get("/:z/:x/:y.pbf")
   @Redirect()
-  findTaxLotTilesets(@Param() params: { z: number; x: number; y: number }) {
-    return {
-      url: `${this.storageConfig.storageUrl}/tilesets/tax_lot/${params.z}/${params.x}/${params.y}.pbf`,
-    };
+  async findTaxLotTilesets(
+    @Param() params: { z: number; x: number; y: number },
+  ) {
+    return await this.taxLotService.findTaxLotTilesets(params);
   }
 }

--- a/src/tax-lot/tax-lot.repository.ts
+++ b/src/tax-lot/tax-lot.repository.ts
@@ -1,5 +1,7 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
+import { StorageConfig } from "src/config";
+import { ConfigType } from "@nestjs/config";
 import { eq, sql } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import {
@@ -13,6 +15,8 @@ export class TaxLotRepository {
   constructor(
     @Inject(DB)
     private readonly db: DbType,
+    @Inject(StorageConfig.KEY)
+    private storageConfig: ConfigType<typeof StorageConfig>,
   ) {}
 
   #checkTaxLotByBbl = this.db.query.taxLot
@@ -128,5 +132,9 @@ export class TaxLotRepository {
     } catch {
       throw new DataRetrievalException();
     }
+  }
+
+  async findTaxLotTilesets(params: { z: number; x: number; y: number }) {
+    return `${this.storageConfig.storageUrl}/tilesets/tax_lot/${params.z}/${params.x}/${params.y}.pbf`;
   }
 }

--- a/src/tax-lot/tax-lot.service.ts
+++ b/src/tax-lot/tax-lot.service.ts
@@ -57,4 +57,11 @@ export class TaxLotService {
       zoningDistrictClasses,
     };
   }
+
+  async findTaxLotTilesets(params: { z: number; x: number; y: number }) {
+    const url = await this.taxLotRepository.findTaxLotTilesets(params);
+    return {
+      url,
+    };
+  }
 }

--- a/src/zoning-district/zoning-district.controller.ts
+++ b/src/zoning-district/zoning-district.controller.ts
@@ -1,16 +1,13 @@
 import {
   Controller,
   Get,
-  Inject,
   Injectable,
   Param,
   Redirect,
   UseFilters,
   UsePipes,
 } from "@nestjs/common";
-import { ConfigType } from "@nestjs/config";
 import { ZoningDistrictService } from "./zoning-district.service";
-import { StorageConfig } from "src/config";
 import { ZodValidationPipe } from "src/pipes/zod-validation-pipe";
 import {
   GetZoningDistrictByIdPathParams,
@@ -32,11 +29,7 @@ import {
 )
 @Controller("zoning-districts")
 export class ZoningDistrictController {
-  constructor(
-    private readonly zoningDistrictService: ZoningDistrictService,
-    @Inject(StorageConfig.KEY)
-    private storageConfig: ConfigType<typeof StorageConfig>,
-  ) {}
+  constructor(private readonly zoningDistrictService: ZoningDistrictService) {}
 
   @Get("/:id")
   @UsePipes(new ZodValidationPipe(getZoningDistrictByIdPathParamsSchema))
@@ -60,11 +53,9 @@ export class ZoningDistrictController {
 
   @Get("/:z/:x/:y.pbf")
   @Redirect()
-  findZoningDistrictTilesets(
+  async findZoningDistrictTilesets(
     @Param() params: { z: number; x: number; y: number },
   ) {
-    return {
-      url: `${this.storageConfig.storageUrl}/tilesets/zoning_district/${params.z}/${params.x}/${params.y}.pbf`,
-    };
+    return await this.zoningDistrictService.findZoningDistrictTilesets(params);
   }
 }

--- a/src/zoning-district/zoning-district.repository.ts
+++ b/src/zoning-district/zoning-district.repository.ts
@@ -1,5 +1,7 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
+import { StorageConfig } from "src/config";
+import { ConfigType } from "@nestjs/config";
 import { eq } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import {
@@ -12,6 +14,8 @@ export class ZoningDistrictRepository {
   constructor(
     @Inject(DB)
     private readonly db: DbType,
+    @Inject(StorageConfig.KEY)
+    private storageConfig: ConfigType<typeof StorageConfig>,
   ) {}
 
   #checkZoningDistrictById = this.db.query.zoningDistrict
@@ -74,5 +78,13 @@ export class ZoningDistrictRepository {
     } catch {
       throw new DataRetrievalException();
     }
+  }
+
+  async findZoningDistrictTilesets(params: {
+    z: number;
+    x: number;
+    y: number;
+  }) {
+    return `${this.storageConfig.storageUrl}/tilesets/zoning_district/${params.z}/${params.x}/${params.y}.pbf`;
   }
 }

--- a/src/zoning-district/zoning-district.service.ts
+++ b/src/zoning-district/zoning-district.service.ts
@@ -28,4 +28,16 @@ export class ZoningDistrictService {
       zoningDistrictClasses,
     };
   }
+
+  async findZoningDistrictTilesets(params: {
+    z: number;
+    x: number;
+    y: number;
+  }) {
+    const url =
+      await this.zoningDistrictRepository.findZoningDistrictTilesets(params);
+    return {
+      url,
+    };
+  }
 }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,6 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
+  "modulePaths": ["<rootDir>/../"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {


### PR DESCRIPTION
# Description
For discussion #118, configure the packages and entity schemas required for end to end testing. 

These changes also refactor the tilesets redirect;  storage url lookup is now delegated to the repositories. The practical reason is to avoid needing to mock the StorageConfig. The architectural justification is "the storage url is a data lookup" 
 