### PR TITLE
155/get zoning districts by tax lot bbl tests

### DIFF
--- a/src/tax-lot/tax-lot.repository.schema.ts
+++ b/src/tax-lot/tax-lot.repository.schema.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
-import { boroughEntitySchema, landUseEntitySchema } from "src/schema";
+import {
+  boroughEntitySchema,
+  landUseEntitySchema,
+  zoningDistrictEntitySchema,
+} from "src/schema";
 import { taxLotEntitySchema } from "src/schema/tax-lot";
+
+export const checkTaxLotByBblRepoSchema = taxLotEntitySchema.pick({
+  bbl: true,
+});
+
+export type CheckTaxLotByBblRepo = z.infer<typeof checkTaxLotByBblRepoSchema>;
 
 export const findByBblRepoSchema = taxLotEntitySchema
   .omit({ boroughId: true, landUseId: true })
@@ -47,3 +57,11 @@ export const findByBblSpatialRepoSchema = findByBblRepoSchema.extend({
 });
 
 export type FindByBblSpatialRepo = z.infer<typeof findByBblSpatialRepoSchema>;
+
+export const findZoningDistrictByTaxLotBblRepoSchema = z.array(
+  zoningDistrictEntitySchema,
+);
+
+export type FindZoningDistrictByTaxLotBblRepo = z.infer<
+  typeof findZoningDistrictByTaxLotBblRepoSchema
+>;

--- a/src/tax-lot/tax-lot.repository.ts
+++ b/src/tax-lot/tax-lot.repository.ts
@@ -13,6 +13,8 @@ import {
 import {
   FindByBblRepo,
   FindByBblSpatialRepo,
+  CheckTaxLotByBblRepo,
+  FindZoningDistrictByTaxLotBblRepo,
 } from "./tax-lot.repository.schema";
 
 export class TaxLotRepository {
@@ -32,7 +34,9 @@ export class TaxLotRepository {
     })
     .prepare("checkTaxLotByBbl");
 
-  async checkTaxLotByBbl(bbl: string) {
+  async checkTaxLotByBbl(
+    bbl: string,
+  ): Promise<CheckTaxLotByBblRepo | undefined> {
     try {
       return await this.#checkTaxLotByBbl.execute({ bbl });
     } catch {
@@ -87,7 +91,9 @@ export class TaxLotRepository {
     }
   }
 
-  async findZoningDistrictByBbl(bbl: string) {
+  async findZoningDistrictByBbl(
+    bbl: string,
+  ): Promise<FindZoningDistrictByTaxLotBblRepo | undefined> {
     try {
       return await this.db
         .select({

--- a/src/tax-lot/tax-lot.service.spec.ts
+++ b/src/tax-lot/tax-lot.service.spec.ts
@@ -6,6 +6,7 @@ import { ResourceNotFoundException } from "src/exception";
 import {
   getTaxLotByBblQueryResponseSchema,
   getTaxLotGeoJsonByBblQueryResponseSchema,
+  getZoningDistrictsByTaxLotBblQueryResponseSchema,
 } from "src/gen";
 
 describe("TaxLotController", () => {
@@ -26,7 +27,7 @@ describe("TaxLotController", () => {
 
   describe("findTaxLotByBbl", () => {
     it("should return a tax lot when requesting a valid bbl", async () => {
-      const { bbl } = taxLotRepository.findByBblSpatialMocks[0];
+      const { bbl } = taxLotRepository.findByBblMocks[0];
       const taxLot = await taxLotService.findTaxLotByBbl(bbl);
       expect(() =>
         getTaxLotByBblQueryResponseSchema.parse(taxLot),
@@ -55,6 +56,24 @@ describe("TaxLotController", () => {
       expect(taxLotService.findTaxLotByBblGeoJson(missingBbl)).rejects.toThrow(
         ResourceNotFoundException,
       );
+    });
+  });
+
+  describe("findZoningDistrictByTaxLotBbl", () => {
+    it("should return an array of zoning district(s) when requesting a valid bbl", async () => {
+      const { bbl } = taxLotRepository.checkTaxLotByBblMocks[0];
+      const zoningDistricts =
+        await taxLotService.findZoningDistrictByTaxLotBbl(bbl);
+      expect(() =>
+        getZoningDistrictsByTaxLotBblQueryResponseSchema.parse(zoningDistricts),
+      ).not.toThrow();
+    });
+
+    it("should throw a resource error when requesting a missing bbl", async () => {
+      const missingBbl = "0123456789";
+      expect(
+        taxLotService.findZoningDistrictByTaxLotBbl(missingBbl),
+      ).rejects.toThrow(ResourceNotFoundException);
     });
   });
 });

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -7,33 +7,27 @@ import {
 } from "src/tax-lot/tax-lot.repository.schema";
 
 export class TaxLotRepositoryMock {
-  checkTaxLotByBblMocks = Array.from(Array(1), (_, seed) =>
-    generateMock(checkTaxLotByBblRepoSchema, { seed }),
+  numberOfMocks = 1;
+
+  checkTaxLotByBblMocks = Array.from(Array(this.numberOfMocks), (_, seed) =>
+    generateMock(checkTaxLotByBblRepoSchema, { seed: seed + 1 }),
   );
 
   async checkTaxLotByBbl(bbl: string) {
     return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblMocks = this.checkTaxLotByBblMocks.map((checkTaxLot) => {
-    const mock = generateMock(findByBblRepoSchema);
-    return {
-      ...mock,
-      ...checkTaxLot,
-    };
-  });
+  findByBblMocks = Array.from(Array(this.numberOfMocks), (_, seed) =>
+    generateMock(findByBblRepoSchema, { seed: seed + 1 }),
+  );
 
   async findByBbl(bbl: string) {
     return this.findByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblSpatialMocks = this.checkTaxLotByBblMocks.map((checkTaxLot) => {
-    const mock = generateMock(findByBblSpatialRepoSchema);
-    return {
-      ...mock,
-      ...checkTaxLot,
-    };
-  });
+  findByBblSpatialMocks = Array.from(Array(this.numberOfMocks), (_, seed) =>
+    generateMock(findByBblSpatialRepoSchema, { seed: seed + 1 }),
+  );
 
   async findByBblSpatial(bbl: string) {
     return this.findByBblSpatialMocks.find((row) => row.bbl === bbl);

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -2,22 +2,57 @@ import { generateMock } from "@anatine/zod-mock";
 import {
   findByBblRepoSchema,
   findByBblSpatialRepoSchema,
+  findZoningDistrictByTaxLotBblRepoSchema,
+  checkTaxLotByBblRepoSchema,
 } from "src/tax-lot/tax-lot.repository.schema";
 
 export class TaxLotRepositoryMock {
-  findByBblMocks = Array.from(Array(10), () =>
-    generateMock(findByBblRepoSchema, { seed: 1 }),
+  checkTaxLotByBblMocks = Array.from(Array(1), (_, seed) =>
+    generateMock(checkTaxLotByBblRepoSchema, { seed }),
   );
+
+  async checkTaxLotByBbl(bbl: string) {
+    return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
+  }
+
+  findByBblMocks = this.checkTaxLotByBblMocks.map((checkTaxLot) => {
+    const mock = generateMock(findByBblRepoSchema);
+    return {
+      ...mock,
+      ...checkTaxLot,
+    };
+  });
 
   async findByBbl(bbl: string) {
     return this.findByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblSpatialMocks = Array.from(Array(10), () =>
-    generateMock(findByBblSpatialRepoSchema, { seed: 1 }),
-  );
+  findByBblSpatialMocks = this.checkTaxLotByBblMocks.map((checkTaxLot) => {
+    const mock = generateMock(findByBblSpatialRepoSchema);
+    return {
+      ...mock,
+      ...checkTaxLot,
+    };
+  });
 
   async findByBblSpatial(bbl: string) {
     return this.findByBblSpatialMocks.find((row) => row.bbl === bbl);
+  }
+
+  findZoningDistrictByTaxLotBblMocks = this.checkTaxLotByBblMocks.map(
+    (checkTaxLot) => {
+      return {
+        [checkTaxLot.bbl]: generateMock(
+          findZoningDistrictByTaxLotBblRepoSchema,
+        ),
+      };
+    },
+  );
+
+  async findZoningDistrictByBbl(bbl: string) {
+    const results = this.findZoningDistrictByTaxLotBblMocks.find(
+      (taxLotZoningDistrictsPair) => bbl in taxLotZoningDistrictsPair,
+    );
+    return results === undefined ? results : results[bbl];
   }
 }


### PR DESCRIPTION
Closes #155 

### Mocking tax lot and zoning districts relationship
I opted to use an object with the bbl string as a computed property name that relates to the array of zoning districts 
`
[ { '1588702147': [ [Object], [Object], [Object] ] } ]
`

It looks similar to the tuple suggestion from @TangoYankee 
`
[ [ { bbl: '1588702147' }, [ [Object], [Object], [Object] ] ] ]
`

But I think that generating a computed key with the bbl string takes care of the extra overhead while still being intuitive to interpret as a relation. 

### Seeding
I updated the tax lot mocks so that we are seeding once in `checkTaxLotByBblMocks` and having other mock functions get their bbls from there. I also changed all arrays to only have one tax lot since we don't need multiple (as of now). 

I will squash the last two commits to 1 seed change commit once approved. 