### PR TITLE
use spread operator to share bbls

### DIFF
--- a/src/tax-lot/tax-lot.repository.schema.ts
+++ b/src/tax-lot/tax-lot.repository.schema.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
-import { boroughEntitySchema, landUseEntitySchema } from "src/schema";
+import {
+  boroughEntitySchema,
+  landUseEntitySchema,
+  zoningDistrictEntitySchema,
+} from "src/schema";
 import { taxLotEntitySchema } from "src/schema/tax-lot";
+
+export const checkTaxLotByBblRepoSchema = z.object({
+  bbl: z.string().regex(RegExp("^([0-9]{10})$")),
+});
+
+export type CheckTaxLotByBblRepo = z.infer<typeof checkTaxLotByBblRepoSchema>;
 
 export const findByBblRepoSchema = taxLotEntitySchema
   .omit({ boroughId: true, landUseId: true })
@@ -47,3 +57,11 @@ export const findByBblSpatialRepoSchema = findByBblRepoSchema.extend({
 });
 
 export type FindByBblSpatialRepo = z.infer<typeof findByBblSpatialRepoSchema>;
+
+export const findZoningDistrictByTaxLotBblRepoSchema = z.array(
+  zoningDistrictEntitySchema,
+);
+
+export type FindZoningDistrictByTaxLotBblRepo = z.infer<
+  typeof findZoningDistrictByTaxLotBblRepoSchema
+>;

--- a/src/tax-lot/tax-lot.repository.ts
+++ b/src/tax-lot/tax-lot.repository.ts
@@ -13,6 +13,8 @@ import {
 import {
   FindByBblRepo,
   FindByBblSpatialRepo,
+  CheckTaxLotByBblRepo,
+  FindZoningDistrictByTaxLotBblRepo,
 } from "./tax-lot.repository.schema";
 
 export class TaxLotRepository {
@@ -32,7 +34,9 @@ export class TaxLotRepository {
     })
     .prepare("checkTaxLotByBbl");
 
-  async checkTaxLotByBbl(bbl: string) {
+  async checkTaxLotByBbl(
+    bbl: string,
+  ): Promise<CheckTaxLotByBblRepo | undefined> {
     try {
       return await this.#checkTaxLotByBbl.execute({ bbl });
     } catch {
@@ -87,7 +91,9 @@ export class TaxLotRepository {
     }
   }
 
-  async findZoningDistrictByBbl(bbl: string) {
+  async findZoningDistrictByBbl(
+    bbl: string,
+  ): Promise<FindZoningDistrictByTaxLotBblRepo | undefined> {
     try {
       return await this.db
         .select({

--- a/src/tax-lot/tax-lot.service.spec.ts
+++ b/src/tax-lot/tax-lot.service.spec.ts
@@ -6,6 +6,7 @@ import { ResourceNotFoundException } from "src/exception";
 import {
   getTaxLotByBblQueryResponseSchema,
   getTaxLotGeoJsonByBblQueryResponseSchema,
+  getZoningDistrictsByTaxLotBblQueryResponseSchema,
 } from "src/gen";
 
 describe("TaxLotController", () => {
@@ -55,6 +56,24 @@ describe("TaxLotController", () => {
       expect(taxLotService.findTaxLotByBblGeoJson(missingBbl)).rejects.toThrow(
         ResourceNotFoundException,
       );
+    });
+  });
+
+  describe("findZoningDistrictByTaxLotBbl", () => {
+    it("should return an array of zoning district(s) when requesting a valid bbl", async () => {
+      const { bbl } = taxLotRepository.checkTaxLotByBblMocks[0];
+      const zoningDistricts =
+        await taxLotService.findZoningDistrictByTaxLotBbl(bbl);
+      expect(() =>
+        getZoningDistrictsByTaxLotBblQueryResponseSchema.parse(zoningDistricts),
+      ).not.toThrow();
+    });
+
+    it("should throw a resource error when requesting a missing bbl", async () => {
+      const missingBbl = "0123456789";
+      expect(
+        taxLotService.findZoningDistrictByTaxLotBbl(missingBbl),
+      ).rejects.toThrow(ResourceNotFoundException);
     });
   });
 });

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -15,7 +15,7 @@ export class TaxLotRepositoryMock {
     return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblMocks = Array.from(Array(1), () =>
+  findByBblMocks = Array.from(this.checkTaxLotByBblMocks, () =>
     generateMock(findByBblRepoSchema, {
       stringMap: {
         bbl: () => this.checkTaxLotByBblMocks[0].bbl,
@@ -27,7 +27,7 @@ export class TaxLotRepositoryMock {
     return this.findByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblSpatialMocks = Array.from(Array(1), () =>
+  findByBblSpatialMocks = Array.from(this.checkTaxLotByBblMocks, () =>
     generateMock(findByBblSpatialRepoSchema, {
       stringMap: {
         bbl: () => this.findByBblMocks[0].bbl,
@@ -39,12 +39,11 @@ export class TaxLotRepositoryMock {
     return this.findByBblSpatialMocks.find((row) => row.bbl === bbl);
   }
 
-  findZoningDistrictByTaxLotBblMocks = this.checkTaxLotByBblMocks.map(
-    (checkTaxLotByBblMock) => {
+  findZoningDistrictByTaxLotBblMocks = Array.from(
+    this.checkTaxLotByBblMocks,
+    (taxLot) => {
       return {
-        [checkTaxLotByBblMock.bbl]: generateMock(
-          findZoningDistrictByTaxLotBblRepoSchema,
-        ),
+        [taxLot.bbl]: generateMock(findZoningDistrictByTaxLotBblRepoSchema),
       };
     },
   );

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -2,9 +2,19 @@ import { generateMock } from "@anatine/zod-mock";
 import {
   findByBblRepoSchema,
   findByBblSpatialRepoSchema,
+  findZoningDistrictByTaxLotBblRepoSchema,
+  checkTaxLotByBblRepoSchema,
 } from "src/tax-lot/tax-lot.repository.schema";
 
 export class TaxLotRepositoryMock {
+  checkTaxLotByBblMocks = [
+    generateMock(checkTaxLotByBblRepoSchema, { seed: 1 }),
+  ];
+
+  async checkTaxLotByBbl(bbl: string) {
+    return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
+  }
+
   findByBblMocks = Array.from(Array(10), () =>
     generateMock(findByBblRepoSchema, { seed: 1 }),
   );
@@ -19,5 +29,22 @@ export class TaxLotRepositoryMock {
 
   async findByBblSpatial(bbl: string) {
     return this.findByBblSpatialMocks.find((row) => row.bbl === bbl);
+  }
+
+  findZoningDistrictByTaxLotBblMocks = this.checkTaxLotByBblMocks.map(
+    (checkTaxLotByBblMock) => {
+      return {
+        [checkTaxLotByBblMock.bbl]: generateMock(
+          findZoningDistrictByTaxLotBblRepoSchema,
+        ),
+      };
+    },
+  );
+
+  async findZoningDistrictByBbl(bbl: string) {
+    const results = this.findZoningDistrictByTaxLotBblMocks.find(
+      (taxLotZoningDistrictsPair) => bbl in taxLotZoningDistrictsPair,
+    );
+    return results === undefined ? results : results[bbl];
   }
 }

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -7,43 +7,47 @@ import {
 } from "src/tax-lot/tax-lot.repository.schema";
 
 export class TaxLotRepositoryMock {
-  checkTaxLotByBblMocks = [
-    generateMock(checkTaxLotByBblRepoSchema, { seed: 1 }),
-  ];
+  checkTaxLotByBblMocks = Array.from(Array(1), (_, seed) =>
+    generateMock(checkTaxLotByBblRepoSchema, { seed }),
+  );
 
   async checkTaxLotByBbl(bbl: string) {
     return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblMocks = Array.from(this.checkTaxLotByBblMocks, () =>
-    generateMock(findByBblRepoSchema, {
-      stringMap: {
-        bbl: () => this.checkTaxLotByBblMocks[0].bbl,
-      },
-    }),
-  );
+  findByBblMocks = this.checkTaxLotByBblMocks.map((checkTaxLot, seed) => {
+    const mock = generateMock(findByBblRepoSchema, { seed });
+    return {
+      ...mock,
+      ...checkTaxLot,
+    };
+  });
 
   async findByBbl(bbl: string) {
     return this.findByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblSpatialMocks = Array.from(this.checkTaxLotByBblMocks, () =>
-    generateMock(findByBblSpatialRepoSchema, {
-      stringMap: {
-        bbl: () => this.findByBblMocks[0].bbl,
-      },
-    }),
+  findByBblSpatialMocks = this.checkTaxLotByBblMocks.map(
+    (checkTaxLot, seed) => {
+      const mock = generateMock(findByBblSpatialRepoSchema, { seed });
+      return {
+        ...mock,
+        ...checkTaxLot,
+      };
+    },
   );
 
   async findByBblSpatial(bbl: string) {
     return this.findByBblSpatialMocks.find((row) => row.bbl === bbl);
   }
 
-  findZoningDistrictByTaxLotBblMocks = Array.from(
-    this.checkTaxLotByBblMocks,
-    (taxLot) => {
+  findZoningDistrictByTaxLotBblMocks = this.checkTaxLotByBblMocks.map(
+    (checkTaxLot, seed) => {
       return {
-        [taxLot.bbl]: generateMock(findZoningDistrictByTaxLotBblRepoSchema),
+        [checkTaxLot.bbl]: generateMock(
+          findZoningDistrictByTaxLotBblRepoSchema,
+          { seed },
+        ),
       };
     },
   );

--- a/test/tax-lot/tax-lot.repository.mock.ts
+++ b/test/tax-lot/tax-lot.repository.mock.ts
@@ -15,16 +15,24 @@ export class TaxLotRepositoryMock {
     return this.checkTaxLotByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblMocks = Array.from(Array(10), () =>
-    generateMock(findByBblRepoSchema, { seed: 1 }),
+  findByBblMocks = Array.from(Array(1), () =>
+    generateMock(findByBblRepoSchema, {
+      stringMap: {
+        bbl: () => this.checkTaxLotByBblMocks[0].bbl,
+      },
+    }),
   );
 
   async findByBbl(bbl: string) {
     return this.findByBblMocks.find((row) => row.bbl === bbl);
   }
 
-  findByBblSpatialMocks = Array.from(Array(10), () =>
-    generateMock(findByBblSpatialRepoSchema, { seed: 1 }),
+  findByBblSpatialMocks = Array.from(Array(1), () =>
+    generateMock(findByBblSpatialRepoSchema, {
+      stringMap: {
+        bbl: () => this.findByBblMocks[0].bbl,
+      },
+    }),
   );
 
   async findByBblSpatial(bbl: string) {


### PR DESCRIPTION
@pratishta 

I'm opening a draft PR against your PR merely to share the code. I don't necessarily think we should merge it. These are mostly to solve brain bugs; though the solutions may come in handy later 

1) When trying make the mocks share bbls, stringMap may not override the bbls but a spread operator will
2) We can make the initial array generation more generalized to support different length arrays, with each element having its own data. 

