### PR TITLE
Add redoc build step to lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "*.{ts,tsx}": [
       "bash -c 'npm run typecheck'",
       "npm run lint"
-    ]
+    ],
+    "openapi/openapi.yaml" : "bash -c 'npm run redoc:build && git add openapi/index.html'"
   }
 }


### PR DESCRIPTION
Ensures that open api site stays in step with documentation

Behavior to look for when reviewing
- If you make a change to `openapi/openapi.api`, then commiting should automatically run the `redoc:build` command and regenerate the `openapi/index.html` file.
- If you make a change somewhere else in the repository (let's say you were updating something in the source code) and the `openapi/openapi.yaml` file is unchanged, then `openapi/index.html` should be skipped

closes #259