### PR TITLE
238 Open API: Document an endpoint to return a single capital project

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -140,6 +140,28 @@ paths:
           $ref: "#/components/responses/NotFound"
         '500':
           $ref: "#/components/responses/InternalServerError"
+  /capital-projects/{managingCode}/{capitalProjectId}:
+    get:
+      summary: 🚧 Find details about a specific capital project
+      operationId: findCapitalProjectByManagingCodeCapitalProjectId
+      tags:
+      - Capital Projects
+      parameters:
+        - $ref: "#/components/parameters/managingCodeParam"
+        - $ref: "#/components/parameters/capitalProjectIdParam"
+      responses:
+        '200':
+          description: An object of capital project details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapitalProjectBudgeted'
+        '400':
+          $ref: "#/components/responses/BadRequest"
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalServerError"
   /capital-projects/{z}/{x}/{y}.pbf:
     get:
       summary: Mapbox Vector Tiles for capital projects


### PR DESCRIPTION
Fixed the issue in the CapitalProjectBudgeted schema, and added the `/capital-projects/{managingCode}/{capitalProjectid}` endpoint.

Completes #238 