### PR TITLE
Allow agency name to be nullable in documentation

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -533,6 +533,7 @@ components:
           example: DOT
         name:
           type: string
+          nullable: true
           description: The full name of the agency.
           example: Department of Transportation
       required:


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-zoning-api/issues/290

Includes generated types and zod schemas