### PR TITLE
298 Removed undefined as option for findMany from:

### DIFF
--- a/src/borough/borough.repository.ts
+++ b/src/borough/borough.repository.ts
@@ -34,7 +34,7 @@ export class BoroughRepository {
     }
   }
 
-  async findMany(): Promise<FindManyRepo | undefined> {
+  async findMany(): Promise<FindManyRepo> {
     try {
       return await this.db.query.borough.findMany();
     } catch {

--- a/src/land-use/land-use.repository.ts
+++ b/src/land-use/land-use.repository.ts
@@ -9,7 +9,7 @@ export class LandUseRepository {
     private readonly db: DbType,
   ) {}
 
-  async findMany(): Promise<FindManyRepo | undefined> {
+  async findMany(): Promise<FindManyRepo> {
     try {
       return await this.db.query.landUse.findMany();
     } catch {


### PR DESCRIPTION
 #### Description
Removed `undefined` as an option from `findMany( )` in the:
 - land-use.repository
 - boroughs.repository


#### Tickets
Closes #298 
