### PR TITLE
Implement find capital projects by community district endpoint

### DIFF
--- a/db/migration/0015_lumpy_the_enforcers.sql
+++ b/db/migration/0015_lumpy_the_enforcers.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "community_district_li_ft_index" ON "community_district" USING GIST ("li_ft");

--- a/db/migration/meta/0015_snapshot.json
+++ b/db/migration/meta/0015_snapshot.json
@@ -1,0 +1,1096 @@
+{
+  "id": "38ff8a47-1437-4bf4-816c-679f5c97647f",
+  "prevId": "b532bc76-85f9-4781-91e3-c8ed9b5a03a2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agency_budget": {
+      "name": "agency_budget",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agency_budget_sponsor_agency_initials_fk": {
+          "name": "agency_budget_sponsor_agency_initials_fk",
+          "tableFrom": "agency_budget",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "sponsor"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.agency": {
+      "name": "agency",
+      "schema": "",
+      "columns": {
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.borough": {
+      "name": "borough",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(1)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.budget_line": {
+      "name": "budget_line",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_line_code_agency_budget_code_fk": {
+          "name": "budget_line_code_agency_budget_code_fk",
+          "tableFrom": "budget_line",
+          "tableTo": "agency_budget",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_line_code_id_pk": {
+          "name": "budget_line_code_id_pk",
+          "columns": [
+            "code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment_fund": {
+      "name": "capital_commitment_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capital_commitment_id": {
+          "name": "capital_commitment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "capital_fund_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk": {
+          "name": "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk",
+          "tableFrom": "capital_commitment_fund",
+          "tableTo": "capital_commitment",
+          "columnsFrom": [
+            "capital_commitment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment_type": {
+      "name": "capital_commitment_type",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(4)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment": {
+      "name": "capital_commitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "char(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_code": {
+          "name": "budget_line_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_id": {
+          "name": "budget_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_type_capital_commitment_type_code_fk": {
+          "name": "capital_commitment_type_capital_commitment_type_code_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_commitment_type",
+          "columnsFrom": [
+            "type"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk": {
+          "name": "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk": {
+          "name": "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "budget_line",
+          "columnsFrom": [
+            "budget_line_code",
+            "budget_line_id"
+          ],
+          "columnsTo": [
+            "code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project_checkbook": {
+      "name": "capital_project_checkbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_checkbook",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project_fund": {
+      "name": "capital_project_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "capital_fund_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "capital_project_fund_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_fund",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project": {
+      "name": "capital_project",
+      "schema": "",
+      "columns": {
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_agency": {
+          "name": "managing_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_date": {
+          "name": "min_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_date": {
+          "name": "max_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "capital_project_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_pnt": {
+          "name": "li_ft_m_pnt",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_poly": {
+          "name": "li_ft_m_poly",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_pnt": {
+          "name": "mercator_fill_m_pnt",
+          "type": "geometry(multiPoint,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_poly": {
+          "name": "mercator_fill_m_poly",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "capital_project_mercator_fill_m_poly_index": {
+          "name": "capital_project_mercator_fill_m_poly_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_mercator_fill_m_pnt_index": {
+          "name": "capital_project_mercator_fill_m_pnt_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_pnt_index": {
+          "name": "capital_project_li_ft_m_pnt_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_poly_index": {
+          "name": "capital_project_li_ft_m_poly_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capital_project_managing_code_managing_code_id_fk": {
+          "name": "capital_project_managing_code_managing_code_id_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "managing_code",
+          "columnsFrom": [
+            "managing_code"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_project_managing_agency_agency_initials_fk": {
+          "name": "capital_project_managing_agency_agency_initials_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "managing_agency"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "capital_project_managing_code_id_pk": {
+          "name": "capital_project_managing_code_id_pk",
+          "columns": [
+            "managing_code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.city_council_district": {
+      "name": "city_council_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "city_council_district_mercator_fill_index": {
+          "name": "city_council_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_mercator_label_index": {
+          "name": "city_council_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_li_ft_index": {
+          "name": "city_council_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.community_district": {
+      "name": "community_district",
+      "schema": "",
+      "columns": {
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_district_li_ft_index": {
+          "name": "community_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_fill_index": {
+          "name": "community_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_label_index": {
+          "name": "community_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_district_borough_id_borough_id_fk": {
+          "name": "community_district_borough_id_borough_id_fk",
+          "tableFrom": "community_district",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_district_borough_id_id_pk": {
+          "name": "community_district_borough_id_id_pk",
+          "columns": [
+            "borough_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.land_use": {
+      "name": "land_use",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.managing_code": {
+      "name": "managing_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(3)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tax_lot": {
+      "name": "tax_lot",
+      "schema": "",
+      "columns": {
+        "bbl": {
+          "name": "bbl",
+          "type": "char(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot": {
+          "name": "lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_use_id": {
+          "name": "land_use_id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tax_lot_borough_id_borough_id_fk": {
+          "name": "tax_lot_borough_id_borough_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tax_lot_land_use_id_land_use_id_fk": {
+          "name": "tax_lot_land_use_id_land_use_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "land_use",
+          "columnsFrom": [
+            "land_use_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district": {
+      "name": "zoning_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district_class": {
+      "name": "zoning_district_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district_zoning_district_class": {
+      "name": "zoning_district_zoning_district_class",
+      "schema": "",
+      "columns": {
+        "zoning_district_id": {
+          "name": "zoning_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoning_district_class_id": {
+          "name": "zoning_district_class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district",
+          "columnsFrom": [
+            "zoning_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district_class",
+          "columnsFrom": [
+            "zoning_district_class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.capital_fund_category": {
+      "name": "capital_fund_category",
+      "schema": "public",
+      "values": [
+        "city-non-exempt",
+        "city-exempt",
+        "city-cost",
+        "non-city-state",
+        "non-city-federal",
+        "non-city-other",
+        "non-city-cost",
+        "total"
+      ]
+    },
+    "public.capital_project_fund_stage": {
+      "name": "capital_project_fund_stage",
+      "schema": "public",
+      "values": [
+        "adopt",
+        "allocate",
+        "commit",
+        "spent"
+      ]
+    },
+    "public.capital_project_category": {
+      "name": "capital_project_category",
+      "schema": "public",
+      "values": [
+        "Fixed Asset",
+        "Lump Sum",
+        "ITT, Vehicles and Equipment"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "Residential",
+        "Commercial",
+        "Manufacturing"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migration/meta/_journal.json
+++ b/db/migration/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1719947385308,
       "tag": "0014_strange_tarantula",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1720202919660,
+      "tag": "0015_lumpy_the_enforcers",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -91,7 +91,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
   /boroughs/{boroughId}/community-districts/{communityDistrictId}/capital-projects:
     get:
-      summary: 🚧 Find paginated capital projects within a specified community district
+      summary: Find paginated capital projects within a specified community district
       operationId: findCapitalProjectsByBoroughIdCommunityDistrictId
       tags:
       - Capital Projects
@@ -786,9 +786,9 @@ components:
       type: string
       nullable: true
       enum:
-        - "Fixed Asset"
-        - "Lump Sum"
-        - "ITT, Vehicles and Equipment"
+        - Fixed Asset
+        - Lump Sum
+        - ITT, Vehicles and Equipment
         - null
       description: The type of Capital Project.
     CapitalProject:

--- a/src/borough/borough.controller.ts
+++ b/src/borough/borough.controller.ts
@@ -3,12 +3,17 @@ import {
   Get,
   Injectable,
   Param,
+  Query,
   UseFilters,
   UsePipes,
 } from "@nestjs/common";
 import { BoroughService } from "./borough.service";
 import {
+  FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams,
+  FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
   FindCommunityDistrictsByBoroughIdPathParams,
+  findCapitalProjectsByBoroughIdCommunityDistrictIdPathParamsSchema,
+  findCapitalProjectsByBoroughIdCommunityDistrictIdQueryParamsSchema,
   findCommunityDistrictsByBoroughIdPathParamsSchema,
 } from "src/gen";
 import {
@@ -42,6 +47,26 @@ export class BoroughController {
   ) {
     return this.boroughService.findCommunityDistrictsByBoroughId(
       params.boroughId,
+    );
+  }
+
+  @Get("/:boroughId/community-districts/:communityDistrictId/capital-projects")
+  async findCapitalProjectsByBoroughIdCommunityDistrictId(
+    @Param(
+      new ZodTransformPipe(
+        findCapitalProjectsByBoroughIdCommunityDistrictIdPathParamsSchema,
+      ),
+    )
+    pathParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams,
+    @Query(
+      new ZodTransformPipe(
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryParamsSchema,
+      ),
+    )
+    queryParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
+  ) {
+    return this.boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId(
+      { ...pathParams, ...queryParams },
     );
   }
 }

--- a/src/borough/borough.module.ts
+++ b/src/borough/borough.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 import { BoroughService } from "./borough.service";
 import { BoroughController } from "./borough.controller";
 import { BoroughRepository } from "./borough.repository";
+import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 
 @Module({
   exports: [BoroughService],
-  providers: [BoroughService, BoroughRepository],
+  providers: [BoroughService, BoroughRepository, CommunityDistrictRepository],
   controllers: [BoroughController],
 })
 export class BoroughModule {}

--- a/src/borough/borough.repository.schema.ts
+++ b/src/borough/borough.repository.schema.ts
@@ -1,3 +1,4 @@
+import { capitalProjectSchema } from "src/gen";
 import { boroughEntitySchema, communityDistrictEntitySchema } from "src/schema";
 import { z } from "zod";
 
@@ -17,4 +18,11 @@ export const findCommunityDistrictsByBoroughIdRepoSchema = z.array(
 
 export type FindCommunityDistrictsByBoroughIdRepo = z.infer<
   typeof findCommunityDistrictsByBoroughIdRepoSchema
+>;
+
+export const findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema =
+  z.array(capitalProjectSchema);
+
+export type FindCapitalProjectsByBoroughIdCommunityDistrictIdRepo = z.infer<
+  typeof findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema
 >;

--- a/src/borough/borough.service.spec.ts
+++ b/src/borough/borough.service.spec.ts
@@ -1,24 +1,36 @@
 import { BoroughRepository } from "src/borough/borough.repository";
+import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 import { BoroughService } from "./borough.service";
 import { BoroughRepositoryMock } from "../../test/borough/borough.repository.mock";
 import { Test } from "@nestjs/testing";
 import {
   findBoroughsQueryResponseSchema,
+  findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictsByBoroughIdQueryResponseSchema,
 } from "src/gen";
 import { ResourceNotFoundException } from "src/exception";
+import { CommunityDistrictRepositoryMock } from "test/community-district/community-district.repository.mock";
 
 describe("Borough service unit", () => {
   let boroughService: BoroughService;
 
-  const boroughRepositoryMock = new BoroughRepositoryMock();
+  const communityDistrictRepositoryMock = new CommunityDistrictRepositoryMock();
+  const boroughRepositoryMock = new BoroughRepositoryMock(
+    communityDistrictRepositoryMock,
+  );
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [BoroughService, BoroughRepository],
+      providers: [
+        BoroughService,
+        BoroughRepository,
+        CommunityDistrictRepository,
+      ],
     })
       .overrideProvider(BoroughRepository)
       .useValue(boroughRepositoryMock)
+      .overrideProvider(CommunityDistrictRepository)
+      .useValue(communityDistrictRepositoryMock)
       .compile();
 
     boroughService = moduleRef.get<BoroughService>(BoroughService);
@@ -51,6 +63,60 @@ describe("Borough service unit", () => {
       const zoningDistrict =
         boroughService.findCommunityDistrictsByBoroughId(missingId);
       expect(zoningDistrict).rejects.toThrow(ResourceNotFoundException);
+    });
+  });
+
+  describe("findCapitalProjectsByBoroughIdCommunityDistrictId", () => {
+    const boroughId = boroughRepositoryMock.checkBoroughByIdMocks[0].id;
+    const communityDistrictId =
+      boroughRepositoryMock.communityDistrictRepoMock
+        .checkCommunityDistrictByIdMocks[0].id;
+    it("service should return a capital projects compliant object using default query params", async () => {
+      const capitalProjects =
+        await boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId({
+          boroughId,
+          communityDistrictId,
+        });
+
+      expect(() =>
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          capitalProjects,
+        ),
+      ).not.toThrow();
+
+      const parsedBody =
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          capitalProjects,
+        );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("service should return a list of capital projects by community district id, using the user specified limit and offset", async () => {
+      const capitalProjects =
+        await boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId({
+          boroughId,
+          communityDistrictId,
+          limit: 10,
+          offset: 3,
+        });
+
+      expect(() =>
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          capitalProjects,
+        ),
+      ).not.toThrow();
+
+      const parsedBody =
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          capitalProjects,
+        );
+      expect(parsedBody.limit).toBe(10);
+      expect(parsedBody.offset).toBe(3);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
     });
   });
 });

--- a/src/borough/borough.service.ts
+++ b/src/borough/borough.service.ts
@@ -1,12 +1,19 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { BoroughRepository } from "./borough.repository";
+import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 import { ResourceNotFoundException } from "src/exception";
+import {
+  FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams,
+  FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
+} from "src/gen";
 
 @Injectable()
 export class BoroughService {
   constructor(
     @Inject(BoroughRepository)
     private readonly boroughRepository: BoroughRepository,
+    @Inject(CommunityDistrictRepository)
+    private readonly communityDistrictRepository: CommunityDistrictRepository,
   ) {}
 
   async findMany() {
@@ -25,6 +32,43 @@ export class BoroughService {
 
     return {
       communityDistricts,
+    };
+  }
+
+  async findCapitalProjectsByBoroughIdCommunityDistrictId({
+    boroughId,
+    communityDistrictId,
+    limit = 20,
+    offset = 0,
+  }: FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams &
+    FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams) {
+    const boroughCheck =
+      await this.boroughRepository.checkBoroughById(boroughId);
+    if (boroughCheck === undefined) throw new ResourceNotFoundException();
+
+    const communityDistrictCheck =
+      await this.communityDistrictRepository.checkCommunityDistrictById(
+        communityDistrictId,
+      );
+    if (communityDistrictCheck === undefined)
+      throw new ResourceNotFoundException();
+
+    const capitalProjects =
+      await this.boroughRepository.findCapitalProjectsByBoroughIdCommunityDistrictId(
+        {
+          boroughId,
+          communityDistrictId,
+          limit,
+          offset,
+        },
+      );
+
+    return {
+      limit,
+      offset,
+      total: capitalProjects.length,
+      order: "managingCode, capitalProjectId",
+      capitalProjects,
     };
   }
 }

--- a/src/community-district/community-district.repository.schema.ts
+++ b/src/community-district/community-district.repository.schema.ts
@@ -1,6 +1,16 @@
+import { communityDistrictEntitySchema } from "src/schema";
 import { mvtEntitySchema } from "src/schema/mvt";
 import { z } from "zod";
 
 export const findTilesRepoSchema = mvtEntitySchema;
 
 export type FindTilesRepo = z.infer<typeof findTilesRepoSchema>;
+
+export const checkByCommunityDistrictIdRepoSchema =
+  communityDistrictEntitySchema.pick({
+    id: true,
+  });
+
+export type CheckByCommunityDistrictIdRepo = z.infer<
+  typeof checkByCommunityDistrictIdRepoSchema
+>;

--- a/src/community-district/community-district.repository.ts
+++ b/src/community-district/community-district.repository.ts
@@ -1,7 +1,10 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { FindCommunityDistrictTilesPathParams } from "src/gen";
-import { FindTilesRepo } from "./community-district.repository.schema";
+import {
+  FindTilesRepo,
+  CheckByCommunityDistrictIdRepo,
+} from "./community-district.repository.schema";
 import { borough, communityDistrict } from "src/schema";
 import { sql, isNotNull, eq } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
@@ -11,6 +14,28 @@ export class CommunityDistrictRepository {
     @Inject(DB)
     private readonly db: DbType,
   ) {}
+
+  #checkCommunityDistrictById = this.db.query.communityDistrict
+    .findFirst({
+      columns: {
+        id: true,
+      },
+      where: (communityDistrict, { eq, sql }) =>
+        eq(communityDistrict.id, sql.placeholder("id")),
+    })
+    .prepare("checkCommunityDistrictId");
+
+  async checkCommunityDistrictById(
+    id: string,
+  ): Promise<CheckByCommunityDistrictIdRepo | undefined> {
+    try {
+      return await this.#checkCommunityDistrictById.execute({
+        id,
+      });
+    } catch {
+      throw new DataRetrievalException();
+    }
+  }
 
   async findTiles(
     params: FindCommunityDistrictTilesPathParams,

--- a/src/schema/community-district.ts
+++ b/src/schema/community-district.ts
@@ -17,6 +17,7 @@ export const communityDistrict = pgTable(
   (table) => {
     return {
       pk: primaryKey({ columns: [table.boroughId, table.id] }),
+      liFtGix: index().using("GIST", table.liFt),
       mercatorFillGix: index().using("GIST", table.mercatorFill),
       mercatorLabelGix: index().using("GIST", table.mercatorLabel),
     };

--- a/test/borough/borough.e2e-spec.ts
+++ b/test/borough/borough.e2e-spec.ts
@@ -2,10 +2,13 @@ import * as request from "supertest";
 import { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
 import { BoroughRepository } from "src/borough/borough.repository";
+import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 import { BoroughRepositoryMock } from "./borough.repository.mock";
+import { CommunityDistrictRepositoryMock } from "../community-district/community-district.repository.mock";
 import { BoroughModule } from "src/borough/borough.module";
 import {
   findBoroughsQueryResponseSchema,
+  findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictsByBoroughIdQueryResponseSchema,
 } from "src/gen";
 import { DataRetrievalException } from "src/exception";
@@ -14,7 +17,10 @@ import { HttpName } from "src/filter";
 describe("Borough e2e", () => {
   let app: INestApplication;
 
-  const boroughRepositoryMock = new BoroughRepositoryMock();
+  const communityDistrictRepositoryMock = new CommunityDistrictRepositoryMock();
+  const boroughRepositoryMock = new BoroughRepositoryMock(
+    communityDistrictRepositoryMock,
+  );
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -22,6 +28,8 @@ describe("Borough e2e", () => {
     })
       .overrideProvider(BoroughRepository)
       .useValue(boroughRepositoryMock)
+      .overrideProvider(CommunityDistrictRepository)
+      .useValue(communityDistrictRepositoryMock)
       .compile();
     app = moduleRef.createNestApplication();
     await app.init();
@@ -95,6 +103,152 @@ describe("Borough e2e", () => {
       const mock = boroughRepositoryMock.checkBoroughByIdMocks[0];
       const response = await request(app.getHttpServer())
         .get(`/boroughs/${mock.id}/community-districts`)
+        .expect(500);
+      expect(response.body.error).toBe(HttpName.INTERNAL_SEVER_ERROR);
+      expect(response.body.message).toBe(dataRetrievalException.message);
+    });
+  });
+
+  describe("findCapitalProjectsByBoroughIdCommunityDistrictId", () => {
+    const borough = boroughRepositoryMock.checkBoroughByIdMocks[0];
+    const communityDistrict =
+      communityDistrictRepositoryMock.checkCommunityDistrictByIdMocks[0];
+    it("should 200 and return capital projects for a given borough id community district id", async () => {
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects`,
+        )
+        .expect(200);
+
+      expect(() => {
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          response.body,
+        );
+      }).not.toThrow();
+
+      const parsedBody =
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          response.body,
+        );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+    });
+
+    it("should 200 and return capital projects for a given borough id community district id with user specified offset and limit", async () => {
+      const limit = 10;
+      const offset = 3;
+
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects?limit=${limit}&offset=${offset}`,
+        )
+        .expect(200);
+
+      expect(() => {
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          response.body,
+        );
+      }).not.toThrow();
+
+      const parsedBody =
+        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
+          response.body,
+        );
+      expect(parsedBody.limit).toBe(10);
+      expect(parsedBody.offset).toBe(3);
+    });
+
+    it("should 404 and when finding by a missing borough id", async () => {
+      const missingId = "9";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${missingId}/community-districts/${communityDistrict.id}/capital-projects`,
+        )
+        .expect(404);
+      expect(response.body.message).toBe(HttpName.NOT_FOUND);
+    });
+
+    it("should 404 and when finding by a missing community district id", async () => {
+      const missingId = "99";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${missingId}/capital-projects`,
+        )
+        .expect(404);
+      expect(response.body.message).toBe(HttpName.NOT_FOUND);
+    });
+
+    it("should 400 and when finding by an invalid borough id", async () => {
+      const invalidId = "MN";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${invalidId}/community-districts/${communityDistrict.id}/capital-projects`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 and when finding by an invalid community district id", async () => {
+      const invalidId = "Q1";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${invalidId}/capital-projects`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 and when finding by an invalid limit", async () => {
+      const limit = "b4d";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects?limit=${limit}`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 and when finding by too high a limit", async () => {
+      const limit = 101;
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects?limit=${limit}`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 and when finding by an invalid limit", async () => {
+      const limit = 0;
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects?limit=${limit}`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 and when finding by an invalid offset", async () => {
+      const offset = "b4d";
+      const response = await request(app.getHttpServer())
+        .get(
+          `/boroughs/${borough.id}/community-districts/${communityDistrict.id}/capital-projects?offset=${offset}`,
+        )
+        .expect(400);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 500 when the database errors", async () => {
+      const dataRetrievalException = new DataRetrievalException();
+      jest
+        .spyOn(boroughRepositoryMock, "checkBoroughById")
+        .mockImplementationOnce(() => {
+          throw dataRetrievalException;
+        });
+
+      const boroughId = boroughRepositoryMock.checkBoroughByIdMocks[0].id;
+      const response = await request(app.getHttpServer())
+        .get(`/boroughs/${boroughId}/community-districts/01/capital-projects`)
         .expect(500);
       expect(response.body.error).toBe(HttpName.INTERNAL_SEVER_ERROR);
       expect(response.body.message).toBe(dataRetrievalException.message);

--- a/test/borough/borough.repository.mock.ts
+++ b/test/borough/borough.repository.mock.ts
@@ -2,10 +2,16 @@ import {
   findManyRepoSchema,
   checkByIdRepoSchema,
   findCommunityDistrictsByBoroughIdRepoSchema,
+  findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema,
 } from "src/borough/borough.repository.schema";
 import { generateMock } from "@anatine/zod-mock";
+import { CommunityDistrictRepositoryMock } from "test/community-district/community-district.repository.mock";
 
 export class BoroughRepositoryMock {
+  communityDistrictRepoMock: CommunityDistrictRepositoryMock;
+  constructor(communityDistrictRepoMock: CommunityDistrictRepositoryMock) {
+    this.communityDistrictRepoMock = communityDistrictRepoMock;
+  }
   numberOfMocks = 1;
 
   checkBoroughByIdMocks = Array.from(Array(this.numberOfMocks), (_, seed) =>
@@ -38,5 +44,27 @@ export class BoroughRepositoryMock {
     );
 
     return results === undefined ? [] : results[id];
+  }
+
+  get findCapitalProjectsByBoroughIdCommunityDistrictIdMocks() {
+    return this.communityDistrictRepoMock.checkCommunityDistrictByIdMocks.map(
+      (checkCommunityDistrict) => {
+        return {
+          [checkCommunityDistrict.id]: generateMock(
+            findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema,
+          ),
+        };
+      },
+    );
+  }
+
+  async findCapitalProjectsByBoroughIdCommunityDistrictId(
+    communityDistrictId: string,
+  ) {
+    const results =
+      this.findCapitalProjectsByBoroughIdCommunityDistrictIdMocks.find(
+        (capitalProjects) => communityDistrictId in capitalProjects,
+      );
+    return results == undefined ? [] : results[communityDistrictId];
   }
 }

--- a/test/community-district/community-district.repository.mock.ts
+++ b/test/community-district/community-district.repository.mock.ts
@@ -1,7 +1,22 @@
 import { generateMock } from "@anatine/zod-mock";
-import { findTilesRepoSchema } from "src/community-district/community-district.repository.schema";
+import {
+  findTilesRepoSchema,
+  checkByCommunityDistrictIdRepoSchema,
+} from "src/community-district/community-district.repository.schema";
 
 export class CommunityDistrictRepositoryMock {
+  numberOfMocks = 1;
+
+  checkCommunityDistrictByIdMocks = Array.from(
+    Array(this.numberOfMocks),
+    (_, seed) =>
+      generateMock(checkByCommunityDistrictIdRepoSchema, { seed: seed + 1 }),
+  );
+
+  async checkCommunityDistrictById(id: string) {
+    return this.checkCommunityDistrictByIdMocks.find((row) => row.id === id);
+  }
+
   findTilesMock = generateMock(findTilesRepoSchema);
 
   /**


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/ae-zoning-api/issues/247

Several things to note:
- Wasn't sure where to place the check for community district ID. First commit (a2a9cd8247fa2dd5b09984b56c8c7f72f8089ba6) has it in `borough` and second commit (bda6221615735c7fca1b31d361a4ea7713652697) has it in its own domain `community-district`
- This endpoint is the first one where we're passing in both path and query params. I pass the `ZodTransformPipe` directly in the pram decorators because adding both param schemas in `UsePipes()` was causing errors. 