### PR TITLE
FindCapitalProjectByManagingCodeCapitalProjectId

### DIFF
--- a/db/migration/0011_old_grey_gargoyle.sql
+++ b/db/migration/0011_old_grey_gargoyle.sql
@@ -1,0 +1,32 @@
+ALTER TABLE "captial_commitment" RENAME TO "capital_commitment";--> statement-breakpoint
+ALTER TABLE "capital_commitment_fund" DROP CONSTRAINT "capital_commitment_fund_capital_commitment_id_captial_commitment_id_fk";
+--> statement-breakpoint
+ALTER TABLE "capital_commitment" DROP CONSTRAINT "captial_commitment_type_capital_commitment_type_code_fk";
+--> statement-breakpoint
+ALTER TABLE "capital_commitment" DROP CONSTRAINT "captial_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk";
+--> statement-breakpoint
+ALTER TABLE "capital_commitment" DROP CONSTRAINT "captial_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "capital_commitment_fund" ADD CONSTRAINT "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk" FOREIGN KEY ("capital_commitment_id") REFERENCES "public"."capital_commitment"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "capital_commitment" ADD CONSTRAINT "capital_commitment_type_capital_commitment_type_code_fk" FOREIGN KEY ("type") REFERENCES "public"."capital_commitment_type"("code") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "capital_commitment" ADD CONSTRAINT "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk" FOREIGN KEY ("managing_code","capital_project_id") REFERENCES "public"."capital_project"("managing_code","id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "capital_commitment" ADD CONSTRAINT "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk" FOREIGN KEY ("budget_line_code","budget_line_id") REFERENCES "public"."budget_line"("code","id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/db/migration/meta/0011_snapshot.json
+++ b/db/migration/meta/0011_snapshot.json
@@ -1,0 +1,1066 @@
+{
+  "id": "7dbc0802-b311-4c0b-937e-b7ec0b9ce931",
+  "prevId": "52959f49-9f66-4386-8492-28ab8cd7f10f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agency_budget": {
+      "name": "agency_budget",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agency_budget_sponsor_agency_initials_fk": {
+          "name": "agency_budget_sponsor_agency_initials_fk",
+          "tableFrom": "agency_budget",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "sponsor"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.agency": {
+      "name": "agency",
+      "schema": "",
+      "columns": {
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.borough": {
+      "name": "borough",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(1)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.budget_line": {
+      "name": "budget_line",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_line_code_agency_budget_code_fk": {
+          "name": "budget_line_code_agency_budget_code_fk",
+          "tableFrom": "budget_line",
+          "tableTo": "agency_budget",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_line_code_id_pk": {
+          "name": "budget_line_code_id_pk",
+          "columns": [
+            "code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment_fund": {
+      "name": "capital_commitment_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capital_commitment_id": {
+          "name": "capital_commitment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "capital_fund_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk": {
+          "name": "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk",
+          "tableFrom": "capital_commitment_fund",
+          "tableTo": "capital_commitment",
+          "columnsFrom": [
+            "capital_commitment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment_type": {
+      "name": "capital_commitment_type",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(4)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_commitment": {
+      "name": "capital_commitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "char(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_code": {
+          "name": "budget_line_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_id": {
+          "name": "budget_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_type_capital_commitment_type_code_fk": {
+          "name": "capital_commitment_type_capital_commitment_type_code_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_commitment_type",
+          "columnsFrom": [
+            "type"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk": {
+          "name": "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk": {
+          "name": "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "budget_line",
+          "columnsFrom": [
+            "budget_line_code",
+            "budget_line_id"
+          ],
+          "columnsTo": [
+            "code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project_checkbook": {
+      "name": "capital_project_checkbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_checkbook",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project_fund": {
+      "name": "capital_project_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "capital_fund_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "capital_project_fund_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_fund",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.capital_project": {
+      "name": "capital_project",
+      "schema": "",
+      "columns": {
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_agency": {
+          "name": "managing_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_date": {
+          "name": "min_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_date": {
+          "name": "max_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "capital_project_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_pnt": {
+          "name": "li_ft_m_pnt",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_poly": {
+          "name": "li_ft_m_poly",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_pnt": {
+          "name": "mercator_fill_m_pnt",
+          "type": "geometry(multiPoint,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_poly": {
+          "name": "mercator_fill_m_poly",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "capital_project_mercator_fill_m_poly_index": {
+          "name": "capital_project_mercator_fill_m_poly_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_mercator_fill_m_pnt_index": {
+          "name": "capital_project_mercator_fill_m_pnt_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_pnt_index": {
+          "name": "capital_project_li_ft_m_pnt_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_poly_index": {
+          "name": "capital_project_li_ft_m_poly_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capital_project_managing_code_managing_code_id_fk": {
+          "name": "capital_project_managing_code_managing_code_id_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "managing_code",
+          "columnsFrom": [
+            "managing_code"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_project_managing_agency_agency_initials_fk": {
+          "name": "capital_project_managing_agency_agency_initials_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "managing_agency"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "capital_project_managing_code_id_pk": {
+          "name": "capital_project_managing_code_id_pk",
+          "columns": [
+            "managing_code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.city_council_district": {
+      "name": "city_council_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "city_council_district_mercator_fill_index": {
+          "name": "city_council_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_mercator_label_index": {
+          "name": "city_council_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.community_district": {
+      "name": "community_district",
+      "schema": "",
+      "columns": {
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_district_mercator_fill_index": {
+          "name": "community_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_label_index": {
+          "name": "community_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_district_borough_id_borough_id_fk": {
+          "name": "community_district_borough_id_borough_id_fk",
+          "tableFrom": "community_district",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_district_borough_id_id_pk": {
+          "name": "community_district_borough_id_id_pk",
+          "columns": [
+            "borough_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.land_use": {
+      "name": "land_use",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.managing_code": {
+      "name": "managing_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(3)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tax_lot": {
+      "name": "tax_lot",
+      "schema": "",
+      "columns": {
+        "bbl": {
+          "name": "bbl",
+          "type": "char(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot": {
+          "name": "lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_use_id": {
+          "name": "land_use_id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tax_lot_borough_id_borough_id_fk": {
+          "name": "tax_lot_borough_id_borough_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tax_lot_land_use_id_land_use_id_fk": {
+          "name": "tax_lot_land_use_id_land_use_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "land_use",
+          "columnsFrom": [
+            "land_use_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district": {
+      "name": "zoning_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district_class": {
+      "name": "zoning_district_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.zoning_district_zoning_district_class": {
+      "name": "zoning_district_zoning_district_class",
+      "schema": "",
+      "columns": {
+        "zoning_district_id": {
+          "name": "zoning_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoning_district_class_id": {
+          "name": "zoning_district_class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district",
+          "columnsFrom": [
+            "zoning_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district_class",
+          "columnsFrom": [
+            "zoning_district_class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.capital_fund_category": {
+      "name": "capital_fund_category",
+      "schema": "public",
+      "values": [
+        "city-non-exempt",
+        "city-exempt",
+        "city-cost",
+        "non-city-state",
+        "non-city-federal",
+        "non-city-other",
+        "non-city-cost",
+        "total"
+      ]
+    },
+    "public.capital_project_fund_stage": {
+      "name": "capital_project_fund_stage",
+      "schema": "public",
+      "values": [
+        "adopt",
+        "allocate",
+        "commit",
+        "spent"
+      ]
+    },
+    "public.capital_project_category": {
+      "name": "capital_project_category",
+      "schema": "public",
+      "values": [
+        "Fixed Asset",
+        "Lump Sum",
+        "ITT, Vehicles and Equipment"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "Residential",
+        "Commercial",
+        "Manufacturing"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migration/meta/_journal.json
+++ b/db/migration/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1719257023128,
       "tag": "0010_military_mathemanic",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1719326696396,
+      "tag": "0011_old_grey_gargoyle",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -144,7 +144,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
   /capital-projects/{managingCode}/{capitalProjectId}:
     get:
-      summary: 🚧 Find details about a specific capital project
+      summary: Find details about a specific capital project
       operationId: findCapitalProjectByManagingCodeCapitalProjectId
       tags:
       - Capital Projects
@@ -761,7 +761,7 @@ components:
           type: string
           description: A string used to refer to the budget line.
           example: '0002Q'
-        sponsoringAgencyInitials:
+        sponsoringAgencies:
           type: string
           description: A string of variable length containing the initials of the sponsoring agency.
           example: DOT
@@ -779,7 +779,7 @@ components:
         - plannedDate
         - budgetLineCode
         - budgetLineId
-        - sponsoringAgencyInitials
+        - sponsoringAgencies
         - budgetType
         - totalValue
     CapitalProjectCategory:
@@ -852,13 +852,13 @@ components:
               type: number
               description: The sum total of commitments for the capital project
               example: 200000
-            sponsoringAgencyInitials:
+            sponsoringAgencies:
               type: array
               items:
                 type: string
               description: An array containing string values representing the sponsoring agencies initials.
               example: ["DOT"]
-            budgetType:
+            budgetTypes:
               type: array
               items:
                   type: string
@@ -866,8 +866,8 @@ components:
               example: ["Highways", "Highway Bridges"]
           required:
             - commitmentsTotal
-            - sponsoringAgencyInitials
-            - budgetType
+            - sponsoringAgencies
+            - budgetTypes
     CityCouncilDistrict:
       type: object
       properties:

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -8,20 +8,41 @@ import {
 } from "@nestjs/common";
 import { Response } from "express";
 import {
+  FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
   FindCapitalProjectTilesPathParams,
+  findCapitalProjectByManagingCodeCapitalProjectIdPathParamsSchema,
   findCapitalProjectTilesPathParamsSchema,
 } from "src/gen";
 import { CapitalProjectService } from "./capital-project.service";
 import {
   BadRequestExceptionFilter,
   InternalServerErrorExceptionFilter,
+  NotFoundExceptionFilter,
 } from "src/filter";
 import { ZodTransformPipe } from "src/pipes/zod-transform-pipe";
 
-@UseFilters(BadRequestExceptionFilter, InternalServerErrorExceptionFilter)
+@UseFilters(
+  BadRequestExceptionFilter,
+  InternalServerErrorExceptionFilter,
+  NotFoundExceptionFilter,
+)
 @Controller("capital-projects")
 export class CapitalProjectController {
   constructor(private readonly capitalProjectService: CapitalProjectService) {}
+
+  @UsePipes(
+    new ZodTransformPipe(
+      findCapitalProjectByManagingCodeCapitalProjectIdPathParamsSchema,
+    ),
+  )
+  @Get("/:managingCode/:capitalProjectId")
+  async findByManagingCodeCapitalProjectId(
+    @Param() params: FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
+  ) {
+    return await this.capitalProjectService.findByManagingCodeCapitalProjectId(
+      params,
+    );
+  }
 
   @UsePipes(new ZodTransformPipe(findCapitalProjectTilesPathParamsSchema))
   @Get("/:z/:x/:y.pbf")

--- a/src/capital-project/capital-project.repository.schema.ts
+++ b/src/capital-project/capital-project.repository.schema.ts
@@ -1,5 +1,23 @@
+import {
+  agencyBudgetEntitySchema,
+  agencyEntitySchema,
+  capitalCommitmentFundEntitySchema,
+  capitalProjectEntitySchema,
+} from "src/schema";
 import { mvtEntitySchema } from "src/schema/mvt";
 import { z } from "zod";
+
+export const findByManagingCodeCapitalProjectIdRepoSchema = z.array(
+  capitalProjectEntitySchema.extend({
+    sponsoringAgencies: z.array(agencyEntitySchema.shape.initials),
+    budgetTypes: z.array(agencyBudgetEntitySchema.shape.type),
+    commitmentsTotal: capitalCommitmentFundEntitySchema.shape.value,
+  }),
+);
+
+export type FindByManagingCodeCapitalProjectIdRepo = z.infer<
+  typeof findByManagingCodeCapitalProjectIdRepoSchema
+>;
 
 export const findTilesRepoSchema = mvtEntitySchema;
 

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -2,7 +2,11 @@ import { CapitalProjectRepositoryMock } from "test/capital-project/capital-proje
 import { CapitalProjectService } from "./capital-project.service";
 import { Test } from "@nestjs/testing";
 import { CapitalProjectRepository } from "./capital-project.repository";
-import { findCapitalProjectTilesQueryResponseSchema } from "src/gen";
+import {
+  findCapitalProjectByManagingCodeCapitalProjectIdQueryResponseSchema,
+  findCapitalProjectTilesQueryResponseSchema,
+} from "src/gen";
+import { ResourceNotFoundException } from "src/exception";
 
 describe("CapitalProjectService", () => {
   let capitalProjectService: CapitalProjectService;
@@ -20,6 +24,37 @@ describe("CapitalProjectService", () => {
     capitalProjectService = moduleRef.get<CapitalProjectService>(
       CapitalProjectService,
     );
+  });
+
+  describe("findByManagingCodeCapitalProjectId", () => {
+    it("should return a capital project with budget details", async () => {
+      const capitalProjectMock =
+        capitalProjectRepository.findByManagingCodeCapitalProjectIdMock[0];
+      const { managingCode, id: capitalProjectId } = capitalProjectMock;
+      const capitalProject =
+        await capitalProjectService.findByManagingCodeCapitalProjectId({
+          managingCode,
+          capitalProjectId,
+        });
+
+      expect(() =>
+        findCapitalProjectByManagingCodeCapitalProjectIdQueryResponseSchema.parse(
+          capitalProject,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should throw a resource error when requesting a missing project", async () => {
+      const missingManagingCode = "890";
+      const missingCapitalProjectId = "ABCD";
+
+      expect(
+        capitalProjectService.findByManagingCodeCapitalProjectId({
+          managingCode: missingManagingCode,
+          capitalProjectId: missingCapitalProjectId,
+        }),
+      ).rejects.toThrow(ResourceNotFoundException);
+    });
   });
 
   describe("findTiles", () => {

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -1,12 +1,28 @@
-import { FindCapitalProjectTilesPathParams } from "src/gen";
+import {
+  FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
+  FindCapitalProjectTilesPathParams,
+} from "src/gen";
 import { CapitalProjectRepository } from "./capital-project.repository";
 import { Inject } from "@nestjs/common";
+import { ResourceNotFoundException } from "src/exception";
 
 export class CapitalProjectService {
   constructor(
     @Inject(CapitalProjectRepository)
     private readonly capitalProjectRepository: CapitalProjectRepository,
   ) {}
+
+  async findByManagingCodeCapitalProjectId(
+    params: FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
+  ) {
+    const capitalProjects =
+      await this.capitalProjectRepository.findByManagingCodeCapitalProjectId(
+        params,
+      );
+
+    if (capitalProjects.length < 1) throw new ResourceNotFoundException();
+    return capitalProjects[0];
+  }
 
   async findTiles(params: FindCapitalProjectTilesPathParams) {
     return await this.capitalProjectRepository.findTiles(params);

--- a/src/gen/schemas/CapitalCommitment.json
+++ b/src/gen/schemas/CapitalCommitment.json
@@ -28,7 +28,7 @@
       "type": "string",
       "example": "0002Q"
     },
-    "sponsoringAgencyInitials": {
+    "sponsoringAgencies": {
       "description": "A string of variable length containing the initials of the sponsoring agency.",
       "type": "string",
       "example": "DOT"
@@ -50,7 +50,7 @@
     "plannedDate",
     "budgetLineCode",
     "budgetLineId",
-    "sponsoringAgencyInitials",
+    "sponsoringAgencies",
     "budgetType",
     "totalValue"
   ],

--- a/src/gen/schemas/CapitalProjectBudgeted.json
+++ b/src/gen/schemas/CapitalProjectBudgeted.json
@@ -68,20 +68,20 @@
           "type": "number",
           "example": 200000
         },
-        "sponsoringAgencyInitials": {
+        "sponsoringAgencies": {
           "description": "An array containing string values representing the sponsoring agencies initials.",
           "type": "array",
           "items": { "type": "string" },
           "example": ["DOT"]
         },
-        "budgetType": {
+        "budgetTypes": {
           "description": "An array containing string values representing the budget types.",
           "type": "array",
           "items": { "type": "string" },
           "example": ["Highways", "Highway Bridges"]
         }
       },
-      "required": ["commitmentsTotal", "sponsoringAgencyInitials", "budgetType"]
+      "required": ["commitmentsTotal", "sponsoringAgencies", "budgetTypes"]
     }
   ],
   "x-readme-ref-name": "CapitalProjectBudgeted"

--- a/src/gen/types/CapitalCommitment.ts
+++ b/src/gen/types/CapitalCommitment.ts
@@ -28,7 +28,7 @@ export type CapitalCommitment = {
    * @description A string of variable length containing the initials of the sponsoring agency.
    * @type string
    */
-  sponsoringAgencyInitials: string;
+  sponsoringAgencies: string;
   /**
    * @description A string of variable length denoting the type of budget.
    * @type string

--- a/src/gen/types/CapitalProjectBudgeted.ts
+++ b/src/gen/types/CapitalProjectBudgeted.ts
@@ -10,10 +10,10 @@ export type CapitalProjectBudgeted = CapitalProject & {
    * @description An array containing string values representing the sponsoring agencies initials.
    * @type array
    */
-  sponsoringAgencyInitials: string[];
+  sponsoringAgencies: string[];
   /**
    * @description An array containing string values representing the budget types.
    * @type array
    */
-  budgetType: string[];
+  budgetTypes: string[];
 };

--- a/src/gen/zod/capitalCommitmentSchema.ts
+++ b/src/gen/zod/capitalCommitmentSchema.ts
@@ -21,7 +21,7 @@ export const capitalCommitmentSchema = z.object({
   budgetLineId: z.coerce
     .string()
     .describe("A string used to refer to the budget line."),
-  sponsoringAgencyInitials: z.coerce
+  sponsoringAgencies: z.coerce
     .string()
     .describe(
       "A string of variable length containing the initials of the sponsoring agency.",

--- a/src/gen/zod/capitalProjectBudgetedSchema.ts
+++ b/src/gen/zod/capitalProjectBudgetedSchema.ts
@@ -8,12 +8,12 @@ export const capitalProjectBudgetedSchema = z
       commitmentsTotal: z.coerce
         .number()
         .describe("The sum total of commitments for the capital project"),
-      sponsoringAgencyInitials: z
+      sponsoringAgencies: z
         .array(z.coerce.string())
         .describe(
           "An array containing string values representing the sponsoring agencies initials.",
         ),
-      budgetType: z
+      budgetTypes: z
         .array(z.coerce.string())
         .describe(
           "An array containing string values representing the budget types.",

--- a/src/schema/capital-commitment-fund.ts
+++ b/src/schema/capital-commitment-fund.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { capitalCommitment } from "./capital-commitment";
 import { capitalFundCategoryEnum } from "./capital-project-fund";
 
-export const captialCommitmentFund = pgTable("capital_commitment_fund", {
+export const capitalCommitmentFund = pgTable("capital_commitment_fund", {
   id: uuid("id").primaryKey(),
   capitalCommitmentId: uuid("capital_commitment_id").references(
     () => capitalCommitment.id,

--- a/src/schema/capital-commitment.ts
+++ b/src/schema/capital-commitment.ts
@@ -13,7 +13,7 @@ import { budgetLine } from "./budget-line";
 import { capitalCommitmentType } from "./capital-commitment-type";
 
 export const capitalCommitment = pgTable(
-  "captial_commitment",
+  "capital_commitment",
   {
     id: uuid("id").primaryKey(),
     type: char("type", { length: 4 }).references(

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -1,7 +1,34 @@
 import { generateMock } from "@anatine/zod-mock";
-import { findTilesRepoSchema } from "src/capital-project/capital-project.repository.schema";
+import {
+  FindByManagingCodeCapitalProjectIdRepo,
+  findByManagingCodeCapitalProjectIdRepoSchema,
+  findTilesRepoSchema,
+} from "src/capital-project/capital-project.repository.schema";
+import { FindCapitalProjectByManagingCodeCapitalProjectIdPathParams } from "src/gen";
 
 export class CapitalProjectRepositoryMock {
+  findByManagingCodeCapitalProjectIdMock = generateMock(
+    findByManagingCodeCapitalProjectIdRepoSchema,
+    {
+      seed: 1,
+      stringMap: {
+        minDate: () => "2018-01-01",
+        maxDate: () => "2045-12-31",
+      },
+    },
+  );
+
+  async findByManagingCodeCapitalProjectId({
+    managingCode,
+    capitalProjectId,
+  }: FindCapitalProjectByManagingCodeCapitalProjectIdPathParams): Promise<FindByManagingCodeCapitalProjectIdRepo> {
+    return this.findByManagingCodeCapitalProjectIdMock.filter(
+      (capitalProject) =>
+        capitalProject.id === capitalProjectId &&
+        capitalProject.managingCode === managingCode,
+    );
+  }
+
   findTilesMock = generateMock(findTilesRepoSchema);
 
   /**


### PR DESCRIPTION
Implement endpoint to find a capital project

Additional tasks
- Renamed the captial_commitments table to fix the type
- Renamed the 'sponsoringAgencyInitials' and 'budgetType'
  - `sponsoreingAgencies` is more consistent with how we use `managingAgency` as a name
  - `budgetTypes` better reflects that it is an array

closes #248