### PR TITLE
342 OpenAPI Implementation for findCapitalProjectGeoJsonByManagingCodeCapitalProjectId endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -173,7 +173,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
   /capital-projects/{managingCode}/{capitalProjectId}/geojson:
     get:
-      summary: 🚧 Find a single capital project as a geojson feature
+      summary: Find a single capital project as a geojson feature
       operationId: findCapitalProjectGeoJsonByManagingCodeCapitalProjectId
       tags: 
         - Capital Projects

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -10,9 +10,11 @@ import { Response } from "express";
 import {
   FindCapitalCommitmentsByManagingCodeCapitalProjectIdPathParams,
   FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
+  FindCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParams,
   FindCapitalProjectTilesPathParams,
   findCapitalCommitmentsByManagingCodeCapitalProjectIdPathParamsSchema,
   findCapitalProjectByManagingCodeCapitalProjectIdPathParamsSchema,
+  findCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParamsSchema,
   findCapitalProjectTilesPathParamsSchema,
 } from "src/gen";
 import { CapitalProjectService } from "./capital-project.service";
@@ -41,6 +43,21 @@ export class CapitalProjectController {
     @Param() params: FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
   ) {
     return await this.capitalProjectService.findByManagingCodeCapitalProjectId(
+      params,
+    );
+  }
+
+  @UsePipes(
+    new ZodTransformPipe(
+      findCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParamsSchema,
+    ),
+  )
+  @Get("/:managingCode/:capitalProjectId/geojson")
+  async findGeoJsonByManagingCodeCapitalProjectId(
+    @Param()
+    params: FindCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParams,
+  ) {
+    return await this.capitalProjectService.findGeoJsonByManagingCodeCapitalProjectId(
       params,
     );
   }

--- a/src/capital-project/capital-project.repository.schema.ts
+++ b/src/capital-project/capital-project.repository.schema.ts
@@ -4,6 +4,8 @@ import {
   capitalCommitmentEntitySchema,
   capitalCommitmentFundEntitySchema,
   capitalProjectEntitySchema,
+  MultiPointSchema,
+  MultiPolygonSchema,
 } from "src/schema";
 import { mvtEntitySchema } from "src/schema/mvt";
 import { z } from "zod";
@@ -18,18 +20,41 @@ export type CheckByManagingCodeCapitalProjectIdRepo = z.infer<
   typeof checkByManagingCodeCapitalProjectIdRepoSchema
 >;
 
-export const findByManagingCodeCapitalProjectIdRepoSchema = z.array(
+export const capitalProjectBudgetedEntitySchema =
   capitalProjectEntitySchema.extend({
     sponsoringAgencies: z.array(agencyEntitySchema.shape.initials),
     budgetTypes: z.array(agencyBudgetEntitySchema.shape.type),
     commitmentsTotal: capitalCommitmentFundEntitySchema.shape.value,
-  }),
+  });
+
+export type CapitalProjectBudgetedEntity = z.infer<
+  typeof capitalProjectBudgetedEntitySchema
+>;
+
+export const findByManagingCodeCapitalProjectIdRepoSchema = z.array(
+  capitalProjectBudgetedEntitySchema,
 );
 
 export type FindByManagingCodeCapitalProjectIdRepo = z.infer<
   typeof findByManagingCodeCapitalProjectIdRepoSchema
 >;
 
+export const capitalProjectBudgetedGeoJsonEntitySchema =
+  capitalProjectBudgetedEntitySchema.extend({
+    geometry: z.union([MultiPointSchema, MultiPolygonSchema]).nullable(),
+  });
+
+export type CapitalProjectBudgetedGeoJsonEntityRepo = z.infer<
+  typeof capitalProjectBudgetedGeoJsonEntitySchema
+>;
+
+export const findGeoJsonByManagingCodeCapitalProjectIdRepoSchema = z.array(
+  capitalProjectBudgetedGeoJsonEntitySchema,
+);
+
+export type FindGeoJsonByManagingCodeCapitalProjectIdRepo = z.infer<
+  typeof findGeoJsonByManagingCodeCapitalProjectIdRepoSchema
+>;
 export const findTilesRepoSchema = mvtEntitySchema;
 
 export type FindTilesRepo = z.infer<typeof findTilesRepoSchema>;

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -5,6 +5,7 @@ import { CapitalProjectRepository } from "./capital-project.repository";
 import {
   findCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponseSchema,
   findCapitalProjectByManagingCodeCapitalProjectIdQueryResponseSchema,
+  findCapitalProjectGeoJsonByManagingCodeCapitalProjectIdQueryResponseSchema,
   findCapitalProjectTilesQueryResponseSchema,
 } from "src/gen";
 import { ResourceNotFoundException } from "src/exception";
@@ -51,6 +52,38 @@ describe("CapitalProjectService", () => {
 
       expect(
         capitalProjectService.findByManagingCodeCapitalProjectId({
+          managingCode: missingManagingCode,
+          capitalProjectId: missingCapitalProjectId,
+        }),
+      ).rejects.toThrow(ResourceNotFoundException);
+    });
+  });
+
+  describe("findGeoJsonByManagingCodeCapitalProjectId", () => {
+    it("should return a capital project geojson with a valid request", async () => {
+      const capitalProjectGeoJsonMock =
+        capitalProjectRepository
+          .findGeoJsonByManagingCodeCapitalProjectIdMock[0];
+      const { managingCode, id: capitalProjectId } = capitalProjectGeoJsonMock;
+      const capitalProjectGeoJson =
+        await capitalProjectService.findGeoJsonByManagingCodeCapitalProjectId({
+          managingCode,
+          capitalProjectId,
+        });
+
+      expect(() =>
+        findCapitalProjectGeoJsonByManagingCodeCapitalProjectIdQueryResponseSchema.parse(
+          capitalProjectGeoJson,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should throw a resource error when requesting a missing project", async () => {
+      const missingManagingCode = "890";
+      const missingCapitalProjectId = "ABCD";
+
+      expect(
+        capitalProjectService.findGeoJsonByManagingCodeCapitalProjectId({
           managingCode: missingManagingCode,
           capitalProjectId: missingCapitalProjectId,
         }),

--- a/src/schema/capital-commitment-fund.ts
+++ b/src/schema/capital-commitment-fund.ts
@@ -19,6 +19,6 @@ export const capitalCommitmentFundEntitySchema = z.object({
   value: z.number(),
 });
 
-export type commitmentFundEntitySchema = z.infer<
+export type CapitalCommitmentFundEntitySchema = z.infer<
   typeof capitalCommitmentFundEntitySchema
 >;

--- a/src/schema/geometry.ts
+++ b/src/schema/geometry.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+export const MultiPointSchema = z
+  .string()
+  .regex(
+    /^{"type":"MultiPoint","coordinates":\[(\[-?[1-9]([0-9]{0,})(\.[0-9]{1,14})?,-?[1-9]([0-9]{0,})(\.[0-9]{1,14})?\])(,\[-?[1-9]([0-9]{0,})(\.[0-9]{1,14})?,-?[1-9]([0-9]{0,})(\.[0-9]{1,14})?\]){0,}\]}$/,
+  );
+
 export const MultiPolygonSchema = z
   .string()
   /**

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -5,11 +5,14 @@ import {
   findByManagingCodeCapitalProjectIdRepoSchema,
   FindCapitalCommitmentsByManagingCodeCapitalProjectIdRepo,
   findCapitalCommitmentsByManagingCodeCapitalProjectIdRepoSchema,
+  FindGeoJsonByManagingCodeCapitalProjectIdRepo,
+  findGeoJsonByManagingCodeCapitalProjectIdRepoSchema,
   findTilesRepoSchema,
 } from "src/capital-project/capital-project.repository.schema";
 import {
   FindCapitalCommitmentsByManagingCodeCapitalProjectIdPathParams,
   FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
+  FindCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParams,
 } from "src/gen";
 
 export class CapitalProjectRepositoryMock {
@@ -79,6 +82,30 @@ export class CapitalProjectRepositoryMock {
         capitalProject.id === capitalProjectId &&
         capitalProject.managingCode === managingCode,
     );
+  }
+
+  findGeoJsonByManagingCodeCapitalProjectIdMock = generateMock(
+    findGeoJsonByManagingCodeCapitalProjectIdRepoSchema,
+    {
+      seed: 1,
+      stringMap: {
+        minDate: () => "2018-01-01",
+        maxDate: () => "2045-12-31",
+      },
+    },
+  );
+
+  async findGeoJsonByManagingCodeCapitalProjectId({
+    managingCode,
+    capitalProjectId,
+  }: FindCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParams): Promise<FindGeoJsonByManagingCodeCapitalProjectIdRepo> {
+    const results = this.findGeoJsonByManagingCodeCapitalProjectIdMock.filter(
+      (capitalProjectGeoJson) =>
+        capitalProjectGeoJson.id === capitalProjectId &&
+        capitalProjectGeoJson.managingCode === managingCode,
+    );
+
+    return results === undefined ? [] : results;
   }
 
   findTilesMock = generateMock(findTilesRepoSchema);


### PR DESCRIPTION
#### Description
Implement endpoint for `findCapitalProjectGeoJsonByManagingCodCapitalProjectId`

  - write controller, module, repository, respo schema, service
  - e2e and service unit tests
  - use m_pnt and m_ply for cp geojson (+ multipoint regex fix)

#### Tickets
Closes #342 