### PR TITLE
369 Sort Capital Commitments by Managing Code Capital Project Id by Date

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -222,8 +222,13 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/CapitalCommitment'
+                  order: 
+                    type: string
+                    description: Capital commitment dates are sorted in ascending order
+                    example: 'plannedDate'
                 required:
                 - capitalCommitments
+                - order
         '400':
           $ref: "#/components/responses/BadRequest"
         '404':

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -1,5 +1,5 @@
 import { Inject } from "@nestjs/common";
-import { isNotNull, sql, and, eq, sum } from "drizzle-orm";
+import { isNotNull, sql, and, eq, sum, asc } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import {
   FindCapitalCommitmentsByManagingCodeCapitalProjectIdPathParams,
@@ -232,6 +232,7 @@ export class CapitalProjectRepository {
           totalValue: sql`${capitalCommitmentFund.value}`.mapWith(Number),
         })
         .from(capitalCommitment)
+        .orderBy(asc(capitalCommitment.plannedDate))
         .leftJoin(
           budgetLine,
           and(

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -118,6 +118,8 @@ describe("CapitalProjectService", () => {
           result,
         ),
       ).not.toThrow();
+
+      expect(result.order).toBe("plannedDate");
     });
 
     it("should throw a resource error when requesting a missing project", async () => {

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -85,6 +85,7 @@ export class CapitalProjectService {
 
     return {
       capitalCommitments,
+      order: "plannedDate",
     };
   }
 }

--- a/src/gen/types/FindCapitalCommitmentsByManagingCodeCapitalProjectId.ts
+++ b/src/gen/types/FindCapitalCommitmentsByManagingCodeCapitalProjectId.ts
@@ -21,6 +21,11 @@ export type FindCapitalCommitmentsByManagingCodeCapitalProjectId200 = {
    * @type array
    */
   capitalCommitments: CapitalCommitment[];
+  /**
+   * @description Capital commitment dates are sorted in ascending order
+   * @type string
+   */
+  order: string;
 };
 /**
  * @description Invalid client request
@@ -43,6 +48,11 @@ export type FindCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponse =
      * @type array
      */
     capitalCommitments: CapitalCommitment[];
+    /**
+     * @description Capital commitment dates are sorted in ascending order
+     * @type string
+     */
+    order: string;
   };
 export type FindCapitalCommitmentsByManagingCodeCapitalProjectIdQuery = {
   Response: FindCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponse;

--- a/src/gen/zod/findCapitalCommitmentsByManagingCodeCapitalProjectIdSchema.ts
+++ b/src/gen/zod/findCapitalCommitmentsByManagingCodeCapitalProjectIdSchema.ts
@@ -22,6 +22,9 @@ export const findCapitalCommitmentsByManagingCodeCapitalProjectIdPathParamsSchem
 export const findCapitalCommitmentsByManagingCodeCapitalProjectId200Schema =
   z.object({
     capitalCommitments: z.array(z.lazy(() => capitalCommitmentSchema)),
+    order: z.coerce
+      .string()
+      .describe("Capital commitment dates are sorted in ascending order"),
   });
 /**
  * @description Invalid client request
@@ -44,4 +47,7 @@ export const findCapitalCommitmentsByManagingCodeCapitalProjectId500Schema =
 export const findCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponseSchema =
   z.object({
     capitalCommitments: z.array(z.lazy(() => capitalCommitmentSchema)),
+    order: z.coerce
+      .string()
+      .describe("Capital commitment dates are sorted in ascending order"),
   });


### PR DESCRIPTION
#### Description
 - updated OpenAPI properties for CCMCCP id to include order variable
 - updated `findCapitalCommitmentsByManagingCodeCapitalProjectId` to sort the capital commitments by `plannedDate`
 - updated CCMCCP service spec to test `results.order` (results=Capital Commitments) value is `plannedDate`

#### TIckets
Closes #369 