### PR TITLE
390 Remove enums from Zoning District Class

### DIFF
--- a/db/migration/0022_known_umar.sql
+++ b/db/migration/0022_known_umar.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "zoning_district_class" ALTER COLUMN "category" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "zoning_district_class" ADD CONSTRAINT "zoning_district_class_category_options" CHECK ("zoning_district_class"."category" IN ('Residential', 'Commercial', 'Manufacturing'));--> statement-breakpoint
+DROP TYPE "public"."category";

--- a/db/migration/meta/0022_snapshot.json
+++ b/db/migration/meta/0022_snapshot.json
@@ -1,0 +1,1130 @@
+{
+  "id": "6683f15e-277f-40d3-b647-b5a0a8c4ab19",
+  "prevId": "4a8c6c40-72e4-4942-ae51-00f6c443b25d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agency_budget": {
+      "name": "agency_budget",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agency_budget_sponsor_agency_initials_fk": {
+          "name": "agency_budget_sponsor_agency_initials_fk",
+          "tableFrom": "agency_budget",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "sponsor"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agency": {
+      "name": "agency",
+      "schema": "",
+      "columns": {
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.borough": {
+      "name": "borough",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(1)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_line": {
+      "name": "budget_line",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_line_code_agency_budget_code_fk": {
+          "name": "budget_line_code_agency_budget_code_fk",
+          "tableFrom": "budget_line",
+          "tableTo": "agency_budget",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_line_code_id_pk": {
+          "name": "budget_line_code_id_pk",
+          "columns": [
+            "code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment_fund": {
+      "name": "capital_commitment_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capital_commitment_id": {
+          "name": "capital_commitment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk": {
+          "name": "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk",
+          "tableFrom": "capital_commitment_fund",
+          "tableTo": "capital_commitment",
+          "columnsFrom": [
+            "capital_commitment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_commitment_fund_capital_fund_category": {
+          "name": "capital_commitment_fund_capital_fund_category",
+          "value": "\"capital_commitment_fund\".\"capital_fund_category\" IN ('city-non-exempt', 'city-exempt', 'city-cost', 'non-city-state', 'non-city-federal', 'non-city-other', 'non-city-cost', 'total')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment_type": {
+      "name": "capital_commitment_type",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(4)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment": {
+      "name": "capital_commitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "char(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_code": {
+          "name": "budget_line_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_line_id": {
+          "name": "budget_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_type_capital_commitment_type_code_fk": {
+          "name": "capital_commitment_type_capital_commitment_type_code_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_commitment_type",
+          "columnsFrom": [
+            "type"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk": {
+          "name": "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk": {
+          "name": "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "budget_line",
+          "columnsFrom": [
+            "budget_line_code",
+            "budget_line_id"
+          ],
+          "columnsTo": [
+            "code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_project_checkbook": {
+      "name": "capital_project_checkbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_checkbook",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_project_fund": {
+      "name": "capital_project_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_fund",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_project_fund_stage_options": {
+          "name": "capital_project_fund_stage_options",
+          "value": "\"capital_project_fund\".\"stage\" IN ('adopt', 'allocate', 'commit', 'spent')"
+        },
+        "capital_project_fund_capital_fund_category": {
+          "name": "capital_project_fund_capital_fund_category",
+          "value": "\"capital_project_fund\".\"capital_fund_category\" IN ('city-non-exempt', 'city-exempt', 'city-cost', 'non-city-state', 'non-city-federal', 'non-city-other', 'non-city-cost', 'total')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.capital_project": {
+      "name": "capital_project",
+      "schema": "",
+      "columns": {
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_agency": {
+          "name": "managing_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_date": {
+          "name": "min_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_date": {
+          "name": "max_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_pnt": {
+          "name": "li_ft_m_pnt",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_poly": {
+          "name": "li_ft_m_poly",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_pnt": {
+          "name": "mercator_fill_m_pnt",
+          "type": "geometry(multiPoint,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_poly": {
+          "name": "mercator_fill_m_poly",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "capital_project_mercator_fill_m_poly_index": {
+          "name": "capital_project_mercator_fill_m_poly_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_mercator_fill_m_pnt_index": {
+          "name": "capital_project_mercator_fill_m_pnt_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_pnt_index": {
+          "name": "capital_project_li_ft_m_pnt_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_poly_index": {
+          "name": "capital_project_li_ft_m_poly_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capital_project_managing_code_managing_code_id_fk": {
+          "name": "capital_project_managing_code_managing_code_id_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "managing_code",
+          "columnsFrom": [
+            "managing_code"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_project_managing_agency_agency_initials_fk": {
+          "name": "capital_project_managing_agency_agency_initials_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "managing_agency"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "capital_project_managing_code_id_pk": {
+          "name": "capital_project_managing_code_id_pk",
+          "columns": [
+            "managing_code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_project_category_options": {
+          "name": "capital_project_category_options",
+          "value": "\"capital_project\".\"category\" IN (\n          'Fixed Asset',\n          'Lump Sum',\n          'ITT, Vehicles, and Equipment'\n          )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.city_council_district": {
+      "name": "city_council_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "city_council_district_mercator_fill_index": {
+          "name": "city_council_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_mercator_label_index": {
+          "name": "city_council_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_li_ft_index": {
+          "name": "city_council_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_district": {
+      "name": "community_district",
+      "schema": "",
+      "columns": {
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_district_li_ft_index": {
+          "name": "community_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_fill_index": {
+          "name": "community_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_label_index": {
+          "name": "community_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_district_borough_id_borough_id_fk": {
+          "name": "community_district_borough_id_borough_id_fk",
+          "tableFrom": "community_district",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_district_borough_id_id_pk": {
+          "name": "community_district_borough_id_id_pk",
+          "columns": [
+            "borough_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.land_use": {
+      "name": "land_use",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managing_code": {
+      "name": "managing_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(3)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_lot": {
+      "name": "tax_lot",
+      "schema": "",
+      "columns": {
+        "bbl": {
+          "name": "bbl",
+          "type": "char(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot": {
+          "name": "lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_use_id": {
+          "name": "land_use_id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tax_lot_borough_id_borough_id_fk": {
+          "name": "tax_lot_borough_id_borough_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tax_lot_land_use_id_land_use_id_fk": {
+          "name": "tax_lot_land_use_id_land_use_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "land_use",
+          "columnsFrom": [
+            "land_use_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoning_district": {
+      "name": "zoning_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoning_district_class": {
+      "name": "zoning_district_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zoning_district_class_category_options": {
+          "name": "zoning_district_class_category_options",
+          "value": "\"zoning_district_class\".\"category\" IN ('Residential', 'Commercial', 'Manufacturing')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zoning_district_zoning_district_class": {
+      "name": "zoning_district_zoning_district_class",
+      "schema": "",
+      "columns": {
+        "zoning_district_id": {
+          "name": "zoning_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoning_district_class_id": {
+          "name": "zoning_district_class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district",
+          "columnsFrom": [
+            "zoning_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district_class",
+          "columnsFrom": [
+            "zoning_district_class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migration/meta/_journal.json
+++ b/db/migration/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1733929910053,
       "tag": "0021_dry_skreet",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1735060700326,
+      "tag": "0022_known_umar",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4058,17 +4058,17 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.10.tgz",
-      "integrity": "sha512-ZbQ4jovQyzHtCGCrzK5NdtW1SYO2fHSsgSY1+/9WdruYCUra+JDkWEXgZ4M3Hv480Dl3OXehAmY1wCOojeMyMQ==",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.15.tgz",
+      "integrity": "sha512-UBejmdiYwaH6fTsz2QFBlC1cJHM+3UDeLZN+CiP9I1fRv2KlBZsmozGLbV5eS1JAVWJB4T5N5yQ0gjN8ZvcS2w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "3.2.0",
-        "tslib": "2.6.3",
+        "path-to-regexp": "3.3.0",
+        "tslib": "2.8.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -4095,16 +4095,23 @@
         }
       }
     },
+    "node_modules/@nestjs/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.5.tgz",
-      "integrity": "sha512-a629r8R8KC4skhdieQ0aIWH5vDBUFntWnWKFyDXQrll6/CllSchfWm87mWF39seaW6bXYtQtAEZY66JrngdrGA==",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.15.tgz",
+      "integrity": "sha512-63ZZPkXHjoDyO7ahGOVcybZCRa7/Scp6mObQKjcX/fTEq1YJeU75ELvMsuQgc8U2opMGOBD7GVuc4DV0oeDHoA==",
+      "license": "MIT",
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
-        "express": "4.21.1",
+        "express": "4.21.2",
         "multer": "1.4.4-lts.1",
-        "tslib": "2.7.0"
+        "tslib": "2.8.1"
       },
       "funding": {
         "type": "opencollective",
@@ -4116,9 +4123,10 @@
       }
     },
     "node_modules/@nestjs/platform-express/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.3",
@@ -7086,9 +7094,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9031,9 +9039,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -9054,7 +9063,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -9069,6 +9078,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -9087,9 +9100,10 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/ext": {
       "version": "1.7.0",
@@ -12857,9 +12871,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13082,9 +13096,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -14076,9 +14090,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "license": "MIT"
     },
     "node_modules/path-type": {

--- a/src/schema/zoning-district-class.ts
+++ b/src/schema/zoning-district-class.ts
@@ -1,19 +1,23 @@
-import { char, pgEnum, pgTable, text } from "drizzle-orm/pg-core";
+import { char, check, pgTable, text } from "drizzle-orm/pg-core";
 import { z } from "zod";
+import { sql } from "drizzle-orm";
 
-export const categoryEnum = pgEnum("category", [
-  "Residential",
-  "Commercial",
-  "Manufacturing",
-]);
-
-export const zoningDistrictClass = pgTable("zoning_district_class", {
-  id: text("id").primaryKey(),
-  category: categoryEnum("category"),
-  description: text("description").notNull(),
-  url: text("url"),
-  color: char("color", { length: 9 }).notNull(),
-});
+export const zoningDistrictClass = pgTable(
+  "zoning_district_class",
+  {
+    id: text("id").primaryKey(),
+    category: text("category"),
+    description: text("description").notNull(),
+    url: text("url"),
+    color: char("color", { length: 9 }).notNull(),
+  },
+  (table) => [
+    check(
+      "zoning_district_class_category_options",
+      sql`${table.category} IN ('Residential', 'Commercial', 'Manufacturing')`,
+    ),
+  ],
+);
 
 export const zoningDistrictClassCategoryEntitySchema = z.enum([
   "Residential",

--- a/src/tax-lot/tax-lot.repository.ts
+++ b/src/tax-lot/tax-lot.repository.ts
@@ -25,6 +25,7 @@ import {
 } from "./tax-lot.repository.schema";
 import { Geometry } from "geojson";
 import { Geom } from "src/types";
+import { ZoningDistrictClassCategory } from "src/gen";
 
 export class TaxLotRepository {
   constructor(
@@ -245,7 +246,7 @@ export class TaxLotRepository {
       return await this.db
         .select({
           id: zoningDistrictClass.id,
-          category: zoningDistrictClass.category,
+          category: sql<ZoningDistrictClassCategory>`${zoningDistrictClass.category}`,
           description: zoningDistrictClass.description,
           url: zoningDistrictClass.url,
           color: zoningDistrictClass.color,

--- a/src/zoning-district-class/zoning-district-class.repository.ts
+++ b/src/zoning-district-class/zoning-district-class.repository.ts
@@ -1,8 +1,9 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import { zoningDistrictClass } from "src/schema";
+import { ZoningDistrictClassCategory } from "src/gen";
 import {
   FindManyRepo,
   FindByIdRepo,
@@ -17,7 +18,15 @@ export class ZoningDistrictClassRepository {
 
   async findMany(): Promise<FindManyRepo> {
     try {
-      return await this.db.query.zoningDistrictClass.findMany();
+      return await this.db
+        .select({
+          id: zoningDistrictClass.id,
+          description: zoningDistrictClass.description,
+          category: sql<ZoningDistrictClassCategory>`${zoningDistrictClass.category}`,
+          color: zoningDistrictClass.color,
+          url: zoningDistrictClass.url,
+        })
+        .from(zoningDistrictClass);
     } catch {
       throw new DataRetrievalException();
     }
@@ -25,9 +34,19 @@ export class ZoningDistrictClassRepository {
 
   async findById(id: string): Promise<FindByIdRepo | undefined> {
     try {
-      return await this.db.query.zoningDistrictClass.findFirst({
-        where: eq(zoningDistrictClass.id, id),
-      });
+      const result = await this.db
+        .select({
+          id: zoningDistrictClass.id,
+          category: sql<ZoningDistrictClassCategory>`${zoningDistrictClass.category}`,
+          description: zoningDistrictClass.description,
+          color: zoningDistrictClass.color,
+          url: zoningDistrictClass.url,
+        })
+        .from(zoningDistrictClass)
+        .where(eq(zoningDistrictClass.id, id))
+        .limit(1);
+
+      return result.length > 0 ? result[0] : undefined;
     } catch {
       throw new DataRetrievalException();
     }
@@ -37,7 +56,7 @@ export class ZoningDistrictClassRepository {
     try {
       return await this.db
         .selectDistinctOn([zoningDistrictClass.category], {
-          category: zoningDistrictClass.category,
+          category: sql<ZoningDistrictClassCategory>`${zoningDistrictClass.category}`,
           color: zoningDistrictClass.color,
         })
         .from(zoningDistrictClass);

--- a/src/zoning-district/zoning-district.repository.ts
+++ b/src/zoning-district/zoning-district.repository.ts
@@ -2,13 +2,14 @@ import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { StorageConfig } from "src/config";
 import { ConfigType } from "@nestjs/config";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import {
   zoningDistrict,
   zoningDistrictClass,
   zoningDistrictZoningDistrictClass,
 } from "src/schema";
+import { ZoningDistrictClassCategory } from "src/gen";
 import {
   CheckByIdRepo,
   FindByIdRepo,
@@ -61,7 +62,7 @@ export class ZoningDistrictRepository {
       return await this.db
         .select({
           id: zoningDistrictClass.id,
-          category: zoningDistrictClass.category,
+          category: sql<ZoningDistrictClassCategory>`${zoningDistrictClass.category}`,
           description: zoningDistrictClass.description,
           url: zoningDistrictClass.url,
           color: zoningDistrictClass.color,


### PR DESCRIPTION
#### Description
- Removed the `categoryEnum` from `zoning-district-class`
 - Changed the category field from a `categoryEnum` to a `text`
 - Added a check constraint to the category field 

#### Tickets
Closes #390 