### PR TITLE
400 Add managing agency filter to capital projects endpoint

### DIFF
--- a/openapi/components/parameters/managingAgencyQueryParam.yaml
+++ b/openapi/components/parameters/managingAgencyQueryParam.yaml
@@ -1,0 +1,9 @@
+name: managingAgency
+required: false
+in: query
+schema:
+  type: string
+  example: 'CUNY'
+  nullable: true
+description: >-
+  The acronym of the managing agency to filter the projects by.

--- a/openapi/paths/capital-projects.yaml
+++ b/openapi/paths/capital-projects.yaml
@@ -6,6 +6,7 @@ get:
   parameters:
     - $ref: ../components/parameters/communityDistrictIdQueryParam.yaml
     - $ref: ../components/parameters/cityCouncilDistrictIdQueryParam.yaml
+    - $ref: ../components/parameters/managingAgencyQueryParam.yaml
     - $ref: ../components/parameters/limitParam.yaml
     - $ref: ../components/parameters/offsetParam.yaml
   responses:

--- a/src/agency/agency.repository.schema.ts
+++ b/src/agency/agency.repository.schema.ts
@@ -4,3 +4,9 @@ import { z } from "zod";
 export const findManyRepoSchema = z.array(agencyEntitySchema);
 
 export type FindManyRepo = z.infer<typeof findManyRepoSchema>;
+
+export const checkByIdRepoSchema = agencyEntitySchema.pick({
+  initials: true,
+});
+
+export type CheckByIdRepo = z.infer<typeof checkByIdRepoSchema>;

--- a/src/agency/agency.repository.ts
+++ b/src/agency/agency.repository.ts
@@ -1,13 +1,35 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { DataRetrievalException } from "src/exception";
-import { FindManyRepo } from "./agency.repository.schema";
+import { CheckByIdRepo, FindManyRepo } from "./agency.repository.schema";
 
 export class AgencyRepository {
   constructor(
     @Inject(DB)
     private readonly db: DbType,
   ) {}
+
+  #checkManagingAgency = this.db.query.agency
+    .findFirst({
+      columns: {
+        initials: true,
+      },
+      where: (agency, { eq, sql }) =>
+        eq(agency.initials, sql.placeholder("initials")),
+    })
+    .prepare("checkManagingAgency");
+
+  async checkManagingAgency(
+    initials: string,
+  ): Promise<CheckByIdRepo | undefined> {
+    try {
+      return await this.#checkManagingAgency.execute({
+        initials,
+      });
+    } catch {
+      throw new DataRetrievalException();
+    }
+  }
 
   async findMany(): Promise<FindManyRepo> {
     try {

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -46,6 +46,7 @@ export class CapitalProjectController {
       offset: queryParams.offset,
       cityCouncilDistrictId: queryParams.cityCouncilDistrictId,
       communityDistrictCombinedId: queryParams.communityDistrictId,
+      managingAgency: queryParams.managingAgency,
     });
   }
 

--- a/src/capital-project/capital-project.module.ts
+++ b/src/capital-project/capital-project.module.ts
@@ -4,6 +4,7 @@ import { CapitalProjectService } from "./capital-project.service";
 import { CapitalProjectRepository } from "./capital-project.repository";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
 
 @Module({
   exports: [CapitalProjectService],
@@ -12,6 +13,7 @@ import { CommunityDistrictRepository } from "src/community-district/community-di
     CapitalProjectRepository,
     CityCouncilDistrictRepository,
     CommunityDistrictRepository,
+    AgencyRepository,
   ],
   controllers: [CapitalProjectController],
 })

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -37,12 +37,14 @@ export class CapitalProjectRepository {
     cityCouncilDistrictId,
     communityDistrictId,
     boroughId,
+    managingAgency,
     limit,
     offset,
   }: {
     cityCouncilDistrictId: string | null;
     communityDistrictId: string | null;
     boroughId: string | null;
+    managingAgency: string | null;
     limit: number;
     offset: number;
   }): Promise<FindManyRepo> {
@@ -80,6 +82,9 @@ export class CapitalProjectRepository {
                   eq(communityDistrict.boroughId, boroughId),
                   eq(communityDistrict.id, communityDistrictId),
                 )
+              : undefined,
+            managingAgency !== null
+              ? eq(capitalProject.managingAgency, managingAgency)
               : undefined,
           ),
         )

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -17,6 +17,7 @@ import {
 } from "./capital-project.repository.schema";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
 
 export class CapitalProjectService {
   constructor(
@@ -24,6 +25,7 @@ export class CapitalProjectService {
     private readonly capitalProjectRepository: CapitalProjectRepository,
     private readonly cityCouncilDistrictRepository: CityCouncilDistrictRepository,
     private readonly communityDistrictRepository: CommunityDistrictRepository,
+    private readonly agencyRepository: AgencyRepository,
   ) {}
 
   async findMany({
@@ -31,11 +33,13 @@ export class CapitalProjectService {
     offset = 0,
     cityCouncilDistrictId = null,
     communityDistrictCombinedId = null,
+    managingAgency = null,
   }: {
     limit?: number;
     offset?: number;
     cityCouncilDistrictId?: string | null;
     communityDistrictCombinedId?: string | null;
+    managingAgency?: string | null;
   }) {
     const checklist: Array<Promise<unknown | undefined>> = [];
     if (cityCouncilDistrictId !== null)
@@ -61,6 +65,9 @@ export class CapitalProjectService {
           communityDistrictId,
         ),
       );
+
+    managingAgency !== null &&
+      checklist.push(this.agencyRepository.checkManagingAgency(managingAgency));
     const checkedList = await Promise.all(checklist);
     if (checkedList.some((result) => result === undefined))
       throw new InvalidRequestParameterException();
@@ -69,6 +76,7 @@ export class CapitalProjectService {
       cityCouncilDistrictId,
       boroughId,
       communityDistrictId,
+      managingAgency,
       limit,
       offset,
     });

--- a/src/gen/types/FindCapitalProjects.ts
+++ b/src/gen/types/FindCapitalProjects.ts
@@ -13,6 +13,11 @@ export type FindCapitalProjectsQueryParams = {
    */
   cityCouncilDistrictId?: string;
   /**
+   * @description The acronym of the managing agency to filter the projects by.
+   * @type string
+   */
+  managingAgency?: string | null;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/src/gen/zod/findCapitalProjectsSchema.ts
+++ b/src/gen/zod/findCapitalProjectsSchema.ts
@@ -18,6 +18,11 @@ export const findCapitalProjectsQueryParamsSchema = z
         "One or two character code to represent city council districts.",
       )
       .optional(),
+    managingAgency: z.coerce
+      .string()
+      .describe("The acronym of the managing agency to filter the projects by.")
+      .nullable()
+      .nullish(),
     limit: z.coerce
       .number()
       .int()

--- a/test/agency/agency.repository.mock.ts
+++ b/test/agency/agency.repository.mock.ts
@@ -7,4 +7,8 @@ export class AgencyRepositoryMock {
   async findMany() {
     return this.findManyMocks;
   }
+
+  async checkManagingAgency(managingAgency: string) {
+    return this.findManyMocks.find((row) => row.initials === managingAgency);
+  }
 }

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -7,6 +7,8 @@ import { CityCouncilDistrictRepository } from "src/city-council-district/city-co
 import { CityCouncilDistrictRepositoryMock } from "test/city-council-district/city-council-district.repository.mock";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 import { CommunityDistrictRepositoryMock } from "test/community-district/community-district.repository.mock";
+import { AgencyRepository } from "src/agency/agency.repository";
+import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import * as request from "supertest";
 import { HttpName } from "src/filter";
 import {
@@ -29,6 +31,7 @@ describe("Capital Projects", () => {
     cityCouncilDistrictRepository,
     communityDistrictRepository,
   );
+  const agencyRepository = new AgencyRepositoryMock();
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [CapitalProjectModule],
@@ -39,6 +42,8 @@ describe("Capital Projects", () => {
       .useValue(cityCouncilDistrictRepository)
       .overrideProvider(CommunityDistrictRepository)
       .useValue(communityDistrictRepository)
+      .overrideProvider(AgencyRepository)
+      .useValue(agencyRepository)
       .compile();
 
     app = moduleRef.createNestApplication();
@@ -180,6 +185,35 @@ describe("Capital Projects", () => {
       const id = "1234";
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?communityDistrictId=${id}`,
+      );
+      expect(response.body.message).toBe(
+        new InvalidRequestParameterException().message,
+      );
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 200 and return capital projects from a specified managing agency", async () => {
+      const managingAgency = "super";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?managingAgency=${managingAgency}`,
+      );
+
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(response.body),
+      ).not.toThrow();
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        response.body,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+      expect(parsedBody.capitalProjects.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should 400 when finding by invalid managing agency", async () => {
+      const managingAgency = "1234";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?managingAgency=${managingAgency}`,
       );
       expect(response.body.message).toBe(
         new InvalidRequestParameterException().message,


### PR DESCRIPTION
### Acceptance Criteria

- [x] The `/capital-projects` endpoint has an optional `managingAgency` query parameter that allows the user to specify managing agency code to filter by
- [x] The query parameter accepts the initials of the agency
- [x] Endpoint must only return capital projects that have the given agency as the managing agency
- [x] Query parameter is documented in OpenAPI and kubb is regenerated
- [x] Add unit and e2e tests

### Validation
- [x] Return a 400 (invalid request parameter exception) when the provided initials do not follow a valid structure for initials
- [x] Return a 400 (invalid request parameter exception) when no city agency exists with the provided initials 

Closes #400 