### PR TITLE
Added Managing Agency filter

### DIFF
--- a/openapi/components/parameters/managingAgencyQueryParam.yaml
+++ b/openapi/components/parameters/managingAgencyQueryParam.yaml
@@ -1,0 +1,8 @@
+name: managingAgency
+required: false
+in: query
+schema:
+  type: string
+  example: 'CUNY'
+description: >-
+  The acronym of the managing agency to filter the projects by.

--- a/openapi/paths/capital-projects.yaml
+++ b/openapi/paths/capital-projects.yaml
@@ -6,6 +6,7 @@ get:
   parameters:
     - $ref: ../components/parameters/communityDistrictIdQueryParam.yaml
     - $ref: ../components/parameters/cityCouncilDistrictIdQueryParam.yaml
+    - $ref: ../components/parameters/managingAgencyQueryParam.yaml
     - $ref: ../components/parameters/limitParam.yaml
     - $ref: ../components/parameters/offsetParam.yaml
   responses:

--- a/src/agency/agency.repository.schema.ts
+++ b/src/agency/agency.repository.schema.ts
@@ -4,3 +4,9 @@ import { z } from "zod";
 export const findManyRepoSchema = z.array(agencyEntitySchema);
 
 export type FindManyRepo = z.infer<typeof findManyRepoSchema>;
+
+export const checkByInitialsRepoSchema = agencyEntitySchema.pick({
+  initials: true,
+});
+
+export type CheckByInitialsRepo = z.infer<typeof checkByInitialsRepoSchema>;

--- a/src/agency/agency.repository.ts
+++ b/src/agency/agency.repository.ts
@@ -1,13 +1,35 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { DataRetrievalException } from "src/exception";
-import { FindManyRepo } from "./agency.repository.schema";
+import { CheckByInitialsRepo, FindManyRepo } from "./agency.repository.schema";
 
 export class AgencyRepository {
   constructor(
     @Inject(DB)
     private readonly db: DbType,
   ) {}
+
+  #checkByInitials = this.db.query.agency
+    .findFirst({
+      columns: {
+        initials: true,
+      },
+      where: (agency, { eq, sql }) =>
+        eq(agency.initials, sql.placeholder("initials")),
+    })
+    .prepare("checkByInitials");
+
+  async checkByInitials(
+    initials: string,
+  ): Promise<CheckByInitialsRepo | undefined> {
+    try {
+      return await this.#checkByInitials.execute({
+        initials,
+      });
+    } catch {
+      throw new DataRetrievalException();
+    }
+  }
 
   async findMany(): Promise<FindManyRepo> {
     try {

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -46,6 +46,7 @@ export class CapitalProjectController {
       offset: queryParams.offset,
       cityCouncilDistrictId: queryParams.cityCouncilDistrictId,
       communityDistrictCombinedId: queryParams.communityDistrictId,
+      managingAgency: queryParams.managingAgency,
     });
   }
 

--- a/src/capital-project/capital-project.module.ts
+++ b/src/capital-project/capital-project.module.ts
@@ -4,6 +4,7 @@ import { CapitalProjectService } from "./capital-project.service";
 import { CapitalProjectRepository } from "./capital-project.repository";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
 
 @Module({
   exports: [CapitalProjectService],
@@ -12,6 +13,7 @@ import { CommunityDistrictRepository } from "src/community-district/community-di
     CapitalProjectRepository,
     CityCouncilDistrictRepository,
     CommunityDistrictRepository,
+    AgencyRepository,
   ],
   controllers: [CapitalProjectController],
 })

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -37,12 +37,14 @@ export class CapitalProjectRepository {
     cityCouncilDistrictId,
     communityDistrictId,
     boroughId,
+    managingAgency,
     limit,
     offset,
   }: {
     cityCouncilDistrictId: string | null;
     communityDistrictId: string | null;
     boroughId: string | null;
+    managingAgency: string | null;
     limit: number;
     offset: number;
   }): Promise<FindManyRepo> {
@@ -80,6 +82,9 @@ export class CapitalProjectRepository {
                   eq(communityDistrict.boroughId, boroughId),
                   eq(communityDistrict.id, communityDistrictId),
                 )
+              : undefined,
+            managingAgency !== null
+              ? eq(capitalProject.managingAgency, managingAgency)
               : undefined,
           ),
         )

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -17,6 +17,7 @@ import {
 } from "./capital-project.repository.schema";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
 
 export class CapitalProjectService {
   constructor(
@@ -24,6 +25,7 @@ export class CapitalProjectService {
     private readonly capitalProjectRepository: CapitalProjectRepository,
     private readonly cityCouncilDistrictRepository: CityCouncilDistrictRepository,
     private readonly communityDistrictRepository: CommunityDistrictRepository,
+    private readonly agencyRepository: AgencyRepository,
   ) {}
 
   async findMany({
@@ -31,11 +33,13 @@ export class CapitalProjectService {
     offset = 0,
     cityCouncilDistrictId = null,
     communityDistrictCombinedId = null,
+    managingAgency = null,
   }: {
     limit?: number;
     offset?: number;
     cityCouncilDistrictId?: string | null;
     communityDistrictCombinedId?: string | null;
+    managingAgency?: string | null;
   }) {
     const checklist: Array<Promise<unknown | undefined>> = [];
     if (cityCouncilDistrictId !== null)
@@ -61,6 +65,10 @@ export class CapitalProjectService {
           communityDistrictId,
         ),
       );
+
+    managingAgency !== null &&
+      checklist.push(this.agencyRepository.checkByInitials(managingAgency));
+
     const checkedList = await Promise.all(checklist);
     if (checkedList.some((result) => result === undefined))
       throw new InvalidRequestParameterException();
@@ -69,6 +77,7 @@ export class CapitalProjectService {
       cityCouncilDistrictId,
       boroughId,
       communityDistrictId,
+      managingAgency,
       limit,
       offset,
     });

--- a/src/gen/types/FindCapitalProjects.ts
+++ b/src/gen/types/FindCapitalProjects.ts
@@ -13,6 +13,11 @@ export type FindCapitalProjectsQueryParams = {
    */
   cityCouncilDistrictId?: string;
   /**
+   * @description The acronym of the managing agency to filter the projects by.
+   * @type string | undefined
+   */
+  managingAgency?: string;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/src/gen/zod/findCapitalProjectsSchema.ts
+++ b/src/gen/zod/findCapitalProjectsSchema.ts
@@ -18,6 +18,10 @@ export const findCapitalProjectsQueryParamsSchema = z
         "One or two character code to represent city council districts.",
       )
       .optional(),
+    managingAgency: z.coerce
+      .string()
+      .describe("The acronym of the managing agency to filter the projects by.")
+      .optional(),
     limit: z.coerce
       .number()
       .int()

--- a/test/agency/agency.repository.mock.ts
+++ b/test/agency/agency.repository.mock.ts
@@ -1,7 +1,26 @@
-import { findManyRepoSchema } from "src/agency/agency.repository.schema";
+import {
+  CheckByInitialsRepo,
+  checkByInitialsRepoSchema,
+  findManyRepoSchema,
+} from "src/agency/agency.repository.schema";
 import { generateMock } from "@anatine/zod-mock";
 
 export class AgencyRepositoryMock {
+  numberOfMocks = 2;
+  checkByInitialsMocks = Array.from(Array(this.numberOfMocks), (_, seed) =>
+    generateMock(checkByInitialsRepoSchema, {
+      seed: seed + 1,
+    }),
+  );
+
+  async checkByInitials(
+    managingAgency: string,
+  ): Promise<CheckByInitialsRepo | undefined> {
+    return this.checkByInitialsMocks.find(
+      (row) => row.initials === managingAgency,
+    );
+  }
+
   findManyMocks = generateMock(findManyRepoSchema);
 
   async findMany() {

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -16,16 +16,20 @@ import {
   FindCapitalProjectByManagingCodeCapitalProjectIdPathParams,
   FindCapitalProjectGeoJsonByManagingCodeCapitalProjectIdPathParams,
 } from "src/gen";
+import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { CityCouncilDistrictRepositoryMock } from "test/city-council-district/city-council-district.repository.mock";
 import { CommunityDistrictRepositoryMock } from "test/community-district/community-district.repository.mock";
 
 export class CapitalProjectRepositoryMock {
+  agencyRepoMock: AgencyRepositoryMock;
   cityCouncilDistrictRepoMock: CityCouncilDistrictRepositoryMock;
   communityDistrictRepoMock: CommunityDistrictRepositoryMock;
   constructor(
+    agencyRepoMock: AgencyRepositoryMock,
     cityCouncilDistrictRepoMock: CityCouncilDistrictRepositoryMock,
     communityDistrictRepoMock: CommunityDistrictRepositoryMock,
   ) {
+    this.agencyRepoMock = agencyRepoMock;
     this.cityCouncilDistrictRepoMock = cityCouncilDistrictRepoMock;
     this.communityDistrictRepoMock = communityDistrictRepoMock;
   }
@@ -33,6 +37,7 @@ export class CapitalProjectRepositoryMock {
   get findManyMocks(): Array<
     [
       {
+        managingAgency: string;
         cityCouncilDistrictId: string;
         boroughId: string;
         communityDistrictId: string;
@@ -40,6 +45,7 @@ export class CapitalProjectRepositoryMock {
       FindManyRepo,
     ]
   > {
+    const agencyMocks = this.agencyRepoMock.checkByInitialsMocks;
     const cityCouncilDistrictIdMocks =
       this.cityCouncilDistrictRepoMock.checkCityCouncilDistrictByIdMocks;
     const communityDistrictIdMocks =
@@ -47,6 +53,7 @@ export class CapitalProjectRepositoryMock {
     return [
       [
         {
+          managingAgency: agencyMocks[0].initials,
           cityCouncilDistrictId: cityCouncilDistrictIdMocks[0].id,
           boroughId: communityDistrictIdMocks[0].boroughId,
           communityDistrictId: communityDistrictIdMocks[0].id,
@@ -61,6 +68,7 @@ export class CapitalProjectRepositoryMock {
       ],
       [
         {
+          managingAgency: agencyMocks[1].initials,
           cityCouncilDistrictId: cityCouncilDistrictIdMocks[0].id,
           boroughId: communityDistrictIdMocks[1].boroughId,
           communityDistrictId: communityDistrictIdMocks[1].id,
@@ -75,6 +83,7 @@ export class CapitalProjectRepositoryMock {
       ],
       [
         {
+          managingAgency: agencyMocks[1].initials,
           cityCouncilDistrictId: cityCouncilDistrictIdMocks[1].id,
           boroughId: communityDistrictIdMocks[1].boroughId,
           communityDistrictId: communityDistrictIdMocks[1].id,
@@ -91,12 +100,14 @@ export class CapitalProjectRepositoryMock {
   }
 
   async findMany({
+    managingAgency,
     boroughId,
     communityDistrictId,
     cityCouncilDistrictId,
     limit,
     offset,
   }: {
+    managingAgency: string | null;
     cityCouncilDistrictId: string | null;
     communityDistrictId: string | null;
     boroughId: string | null;
@@ -105,6 +116,12 @@ export class CapitalProjectRepositoryMock {
   }) {
     return this.findManyMocks
       .reduce((acc: FindManyRepo, [criteria, capitalProjects]) => {
+        if (
+          managingAgency !== null &&
+          criteria.managingAgency !== managingAgency
+        )
+          return acc;
+
         if (
           cityCouncilDistrictId !== null &&
           criteria.cityCouncilDistrictId !== cityCouncilDistrictId


### PR DESCRIPTION
Add managing agency filter to capital projects endpoint

closes #400

## Details

Builds off PR #419

[A compare between this PR and the original](https://github.com/NYCPlanning/ae-zoning-api/compare/400/add-managing-agency-filter-to-capital-projects-endpoint..ty/400/draft?expand=1)

- Remove `nullable` from the managingAgency query parameter openAPI spec 
  - While we privately default `managingAgency` to null, the public-facing API shouldn't accept `null`
- Update names of methods/types/schemas for checking managingAgency
  - Uses `checkByInitials` as the base
  - This name reflects that we may use the method generally to check for agencies (not just for managing agency)
  - `Initials` informs the field name we are using as the primary key/id
- Update the agency repository mock to have the type/structure of the mock data returned by checkByInitials match the data structure returned by the real repository
- Update the capital project repository mock to handle a managing agency query parameter
- Have capital project service test use the initials from the mock data
- Update the description of the capital project e2e that results in a 400
  - Query parameters that accept a generic "string" type with no shape specifiers are basically always valid. Much of this comes from the nature of URLS- they all come through as strings. Anyway, the 400 is triggered because the managing agency doesn't exist in the list of known agencies.
   