### PR TITLE
399 Add minimum and maximum commitments total filter to capital projects endpoint

### DIFF
--- a/openapi/components/parameters/commitmentsTotalMaxQueryParam.yaml
+++ b/openapi/components/parameters/commitmentsTotalMaxQueryParam.yaml
@@ -1,0 +1,9 @@
+name: commitmentsTotalMax
+required: false
+in: query
+schema:
+  type: string
+  pattern: ^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\.[0-9]{2})?$
+  example: '1,001.01'
+description: >-
+  Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.

--- a/openapi/components/parameters/commitmentsTotalMinQueryParam.yaml
+++ b/openapi/components/parameters/commitmentsTotalMinQueryParam.yaml
@@ -1,0 +1,9 @@
+name: commitmentsTotalMin
+required: false
+in: query
+schema:
+  type: string
+  pattern: ^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\.[0-9]{2})?$
+  example: '1000'
+description: >-
+  Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.

--- a/openapi/paths/capital-projects.yaml
+++ b/openapi/paths/capital-projects.yaml
@@ -8,6 +8,8 @@ get:
     - $ref: ../components/parameters/cityCouncilDistrictIdQueryParam.yaml
     - $ref: ../components/parameters/managingAgencyQueryParam.yaml
     - $ref: ../components/parameters/agencyBudgetParam.yaml
+    - $ref: ../components/parameters/commitmentsTotalMinQueryParam.yaml
+    - $ref: ../components/parameters/commitmentsTotalMaxQueryParam.yaml
     - $ref: ../components/parameters/limitParam.yaml
     - $ref: ../components/parameters/offsetParam.yaml
   responses:

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -48,6 +48,8 @@ export class CapitalProjectController {
       communityDistrictCombinedId: queryParams.communityDistrictId,
       managingAgency: queryParams.managingAgency,
       agencyBudget: queryParams.agencyBudget,
+      commitmentsTotalMin: queryParams.commitmentsTotalMin,
+      commitmentsTotalMax: queryParams.commitmentsTotalMax,
     });
   }
 

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -194,6 +194,55 @@ describe("CapitalProjectService", () => {
         }),
       ).rejects.toThrow(InvalidRequestParameterException);
     });
+
+    it("service should return a list of capital projects with total commitments above the minimum, using the default limit and offset", async () => {
+      const commitmentsTotalMin = "0";
+      const resource = await capitalProjectService.findMany({
+        commitmentsTotalMin,
+      });
+
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(resource),
+      ).not.toThrow();
+      const parsedResource =
+        findCapitalProjectsQueryResponseSchema.parse(resource);
+      expect(parsedResource.limit).toBe(20);
+      expect(parsedResource.offset).toBe(0);
+      expect(parsedResource.capitalProjects.length).toBe(8);
+      expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("service should return a list of capital projects with total commitments below the maximum, using the default limit and offset", async () => {
+      const commitmentsTotalMax = "10000000000";
+      const resource = await capitalProjectService.findMany({
+        commitmentsTotalMax,
+      });
+
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(resource),
+      ).not.toThrow();
+      const parsedResource =
+        findCapitalProjectsQueryResponseSchema.parse(resource);
+      expect(parsedResource.limit).toBe(20);
+      expect(parsedResource.offset).toBe(0);
+      expect(parsedResource.capitalProjects.length).toBe(8);
+      expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should return a InvalidRequestParameterException error when the maximum total commitments is less than the minimum", async () => {
+      const commitmentsTotalMin = "10000000000";
+      const commitmentsTotalMax = "0";
+
+      expect(
+        capitalProjectService.findMany({
+          commitmentsTotalMin,
+          commitmentsTotalMax,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
     it("should throw an error when requesting an agency budget that does not exist", async () => {
       const missingAgencyBudget = "hr";
 

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -37,6 +37,8 @@ export class CapitalProjectService {
     communityDistrictCombinedId = null,
     managingAgency = null,
     agencyBudget = null,
+    commitmentsTotalMin = null,
+    commitmentsTotalMax = null,
   }: {
     limit?: number;
     offset?: number;
@@ -44,7 +46,20 @@ export class CapitalProjectService {
     communityDistrictCombinedId?: string | null;
     managingAgency?: string | null;
     agencyBudget?: string | null;
+    commitmentsTotalMin?: string | null;
+    commitmentsTotalMax?: string | null;
   }) {
+    const min = commitmentsTotalMin
+      ? parseFloat(commitmentsTotalMin.replaceAll(",", ""))
+      : null;
+    const max = commitmentsTotalMax
+      ? parseFloat(commitmentsTotalMax.replaceAll(",", ""))
+      : null;
+
+    if (min !== null && max !== null && min > max) {
+      throw new InvalidRequestParameterException();
+    }
+
     const checklist: Array<Promise<unknown | undefined>> = [];
     if (cityCouncilDistrictId !== null)
       checklist.push(
@@ -77,6 +92,7 @@ export class CapitalProjectService {
     if (agencyBudget !== null) {
       checklist.push(this.agencyBudgetRepository.checkByCode(agencyBudget));
     }
+
     const checkedList = await Promise.all(checklist);
 
     if (checkedList.some((result) => result === undefined))
@@ -88,6 +104,8 @@ export class CapitalProjectService {
       communityDistrictId,
       managingAgency,
       agencyBudget,
+      commitmentsTotalMin: min,
+      commitmentsTotalMax: max,
       limit,
       offset,
     });

--- a/src/gen/types/FindCapitalProjects.ts
+++ b/src/gen/types/FindCapitalProjects.ts
@@ -23,6 +23,16 @@ export type FindCapitalProjectsQueryParams = {
    */
   agencyBudget?: string;
   /**
+   * @description Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMin?: string;
+  /**
+   * @description Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.
+   * @type string | undefined
+   */
+  commitmentsTotalMax?: string;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/src/gen/zod/findCapitalProjectsSchema.ts
+++ b/src/gen/zod/findCapitalProjectsSchema.ts
@@ -28,6 +28,20 @@ export const findCapitalProjectsQueryParamsSchema = z
         "The two character alphabetic string containing the letters used to refer to the agency budget code.",
       )
       .optional(),
+    commitmentsTotalMin: z.coerce
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Minimum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
+    commitmentsTotalMax: z.coerce
+      .string()
+      .regex(new RegExp("^[+-]?[0-9]{1,3}(?:,?[0-9]{3})*(?:\\.[0-9]{2})?$"))
+      .describe(
+        "Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
+      )
+      .optional(),
     limit: z.coerce
       .number()
       .int()

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -261,6 +261,78 @@ describe("Capital Projects", () => {
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
+    it("should 200 and return capital projects with total capital commitments above a specified minimum", async () => {
+      const commitmentsTotalMin = "0";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}`,
+      );
+
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(response.body),
+      ).not.toThrow();
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        response.body,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.capitalProjects.length).toBe(8);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should 400 when filtering with an invalid commitmentsTotalMin", async () => {
+      const commitmentsTotalMin = "01,0.0001";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}`,
+      );
+      expect(response.body.message).toBe(
+        new InvalidRequestParameterException().message,
+      );
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 200 and return capital projects with total capital commitments below a specified maximum", async () => {
+      const commitmentsTotalMax = "100000000";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?commitmentsTotalMax=${commitmentsTotalMax}`,
+      );
+
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(response.body),
+      ).not.toThrow();
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        response.body,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.capitalProjects.length).toBe(8);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should 400 when filtering with an invalid commitmentsTotalMax", async () => {
+      const commitmentsTotalMax = "99,99";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?commitmentsTotalMax=${commitmentsTotalMax}`,
+      );
+      expect(response.body.message).toBe(
+        new InvalidRequestParameterException().message,
+      );
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 when the specified maximum is less than the specified minimum", async () => {
+      const commitmentsTotalMin = "100000000";
+      const commitmentsTotalMax = "10";
+      const response = await request(app.getHttpServer()).get(
+        `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}&commitmentsTotalMax=${commitmentsTotalMax}`,
+      );
+      expect(response.body.message).toBe(
+        new InvalidRequestParameterException().message,
+      );
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
     it("should 500 when there is a data retrieval error", async () => {
       const dataRetrievalException = new DataRetrievalException();
       jest

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -46,6 +46,7 @@ export class CapitalProjectRepositoryMock {
         boroughId: string;
         communityDistrictId: string;
         agencyBudget: string;
+        commitmentsTotal: number;
       },
       FindManyRepo,
     ]
@@ -64,6 +65,7 @@ export class CapitalProjectRepositoryMock {
           boroughId: communityDistrictIdMocks[0].boroughId,
           communityDistrictId: communityDistrictIdMocks[0].id,
           agencyBudget: agencyBudgetMocks[0].code,
+          commitmentsTotal: 100,
         },
         generateMock(findManyRepoSchema, {
           seed: 1,
@@ -80,6 +82,7 @@ export class CapitalProjectRepositoryMock {
           boroughId: communityDistrictIdMocks[1].boroughId,
           communityDistrictId: communityDistrictIdMocks[1].id,
           agencyBudget: agencyBudgetMocks[1].code,
+          commitmentsTotal: 200,
         },
         generateMock(findManyRepoSchema, {
           seed: 2,
@@ -96,6 +99,7 @@ export class CapitalProjectRepositoryMock {
           boroughId: communityDistrictIdMocks[1].boroughId,
           communityDistrictId: communityDistrictIdMocks[1].id,
           agencyBudget: agencyBudgetMocks[1].code,
+          commitmentsTotal: 300,
         },
         generateMock(findManyRepoSchema, {
           seed: 3,
@@ -114,6 +118,8 @@ export class CapitalProjectRepositoryMock {
     communityDistrictId,
     cityCouncilDistrictId,
     agencyBudget,
+    commitmentsTotalMin,
+    commitmentsTotalMax,
     limit,
     offset,
   }: {
@@ -122,6 +128,8 @@ export class CapitalProjectRepositoryMock {
     communityDistrictId: string | null;
     boroughId: string | null;
     agencyBudget: string | null;
+    commitmentsTotalMin: number | null;
+    commitmentsTotalMax: number | null;
     limit: number;
     offset: number;
   }) {
@@ -150,6 +158,16 @@ export class CapitalProjectRepositoryMock {
         if (agencyBudget !== null && criteria.agencyBudget !== agencyBudget)
           return acc;
 
+        if (
+          commitmentsTotalMin !== null &&
+          criteria.commitmentsTotal <= commitmentsTotalMin
+        )
+          return acc;
+        if (
+          commitmentsTotalMax !== null &&
+          criteria.commitmentsTotal >= commitmentsTotalMax
+        )
+          return acc;
         return acc.concat(capitalProjects);
       }, [])
       .slice(offset, limit + offset);


### PR DESCRIPTION
### Acceptance Criteria

- [x] `capital-projects` endpoint has two optional (but not nullable) query parameters to filter projects based on the funding total
  - `commitmentsTotalMin`, for a minimum total of funding
  - `commitmentsTotalMax`, for a maximum total of funding
- [x] The parameters represent USD (with no multiplier like "Millions")   
- [x] The query parameters may be used together or on their own 
  - When only `commitmentsTotalMin` is used, all returned projects must have total funding above or equal to the minimum
  - When only `commitmentsTotalMax` is used, all returned projects must have total funding below or equal to the maximum
  - When both parameters are used together, all project must have total funding within the range, inclusive.
- [x] New query parameters are reflected in OpenAPI spec (regenerate files as needed)
- [x] Add unit and e2e tests for new query parameters
   - Capital project repository mock should be updated to add "commitmentsTotal" filtering criteria
   - A service test should ensure that the capital project service is successfully passing the 'commitmentsTotalMin` parameter to the repository 
   - A service test should ensure that the capital project service is successfully passing the 'commitmentsTotalMax` parameter to the repository
   - A service test should ensure the capital project service throws an error when the maximum is greater than the minimum
   - An e2e test should ensure the endpoint 200s and successfully returns a list of capital projects when filtering by a valid commitmentsTotalMin
   - An e2e test should ensure the endpoint 400s when filtering by an invalid commitmentsTotalMin
   - An e2e test should ensure the endpoint 200s and successfully returns a list of capital projects when filtering by a valid commitmentsTotalMax
   - An e2e test should ensure the endpoint 400s when filtering by an invalid commitmentsTotalMax
   - An e2e test should ensure the endpoint 400s when filtering by a commitmentsTotalMax higher than a commitmentsTotalMin  

#### Validations
- [x] Return a 400 (invalid request parameter exception) if either provided value has more than two digits after the decimal place or otherwise does not reflect a valid US dollar value
- [x] Return a 400 (invalid request parameter exception) if both max and min are provided, but max is less than the min

Closes #399 