### PR TITLE
424 Agency budgets endpoint OAS typo

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -40,7 +40,7 @@ tags:
 paths:
   /agencies:
     $ref: paths/agencies.yaml
-  /agencyBugdets:
+  /agency-bugdets:
     $ref: paths/agency-budgets.yaml
   /boroughs:
     $ref: paths/boroughs.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -40,7 +40,7 @@ tags:
 paths:
   /agencies:
     $ref: paths/agencies.yaml
-  /agency-bugdets:
+  /agency-budgets:
     $ref: paths/agency-budgets.yaml
   /boroughs:
     $ref: paths/boroughs.yaml

--- a/src/gen/zod/operations.ts
+++ b/src/gen/zod/operations.ts
@@ -773,7 +773,7 @@ export const paths = {
   "/agencies": {
     get: operations["findAgencies"],
   },
-  "/agencyBugdets": {
+  "/agency-bugdets": {
     get: operations["findAgencyBudgets"],
   },
   "/boroughs": {

--- a/src/gen/zod/operations.ts
+++ b/src/gen/zod/operations.ts
@@ -773,7 +773,7 @@ export const paths = {
   "/agencies": {
     get: operations["findAgencies"],
   },
-  "/agency-bugdets": {
+  "/agency-budgets": {
     get: operations["findAgencyBudgets"],
   },
   "/boroughs": {


### PR DESCRIPTION
This Issue is for fixing a couple typos in the OAS spec for the agency budgets endpoint implemented for #401. The spec [defines the path](https://github.com/NYCPlanning/ae-zoning-api/blob/main/openapi/openapi.yaml#L43) as `/agencyBugdets` whereas the [controller correctly sets it as](https://github.com/NYCPlanning/ae-zoning-api/blob/main/src/agency-budget/agency-budget.controller.ts#L6) `agency-budgets`. 
 
- [x] Change path in OAS file to dash case instead of camel
- [x] Fix typo in path in OAS file - bu**dg**ets not bu**gd**ets
- [x] Regen Kubb files

Closes #424 