### PR TITLE
Agency budgets in capital project tiles

### DIFF
--- a/src/borough/borough.repository.ts
+++ b/src/borough/borough.repository.ts
@@ -164,6 +164,11 @@ export class BoroughRepository {
           commitmentsTotal: sum(capitalCommitmentFund.value).as(
             "commitmentsTotal",
           ),
+          agencyBudgets: sql<
+            Array<string>
+          >`ARRAY_TO_JSON(ARRAY_AGG(DISTINCT ${capitalCommitment.budgetLineCode}))`.as(
+            "agencyBudgets",
+          ),
           geom: sql<string>`
             CASE
               WHEN ${capitalProject.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -324,6 +324,11 @@ export class CapitalProjectRepository {
           commitmentsTotal: sum(capitalCommitmentFund.value).as(
             "commitmentsTotal",
           ),
+          agencyBudgets: sql<
+            Array<string>
+          >`ARRAY_TO_JSON(ARRAY_AGG(DISTINCT ${capitalCommitment.budgetLineCode}))`.as(
+            "agencyBudgets",
+          ),
           geom: sql<string>`
             CASE
               WHEN ${capitalProject.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})

--- a/src/city-council-district/city-council-district.repository.ts
+++ b/src/city-council-district/city-council-district.repository.ts
@@ -106,6 +106,11 @@ export class CityCouncilDistrictRepository {
           commitmentsTotal: sum(capitalCommitmentFund.value).as(
             "commitmentsTotal",
           ),
+          agencyBudgets: sql<
+            Array<string>
+          >`ARRAY_TO_JSON(ARRAY_AGG(DISTINCT ${capitalCommitment.budgetLineCode}))`.as(
+            "agencyBudgets",
+          ),
           geom: sql<string>`
             CASE
               WHEN ${capitalProject.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})


### PR DESCRIPTION
Add agency budgets as JSON arrays in tiles for capital projects

closes #427

## Testing
Frontend branch to parse and view data served by these API changes: [`test/427`](https://github.com/NYCPlanning/ae-cp-map/tree/test/427)