### PR TITLE
Total capital projects matches

### DIFF
--- a/openapi/components/schemas/CapitalProjectPage.yaml
+++ b/openapi/components/schemas/CapitalProjectPage.yaml
@@ -6,5 +6,12 @@ allOf:
         type: array
         items:
           $ref: ./CapitalProject.yaml
+      totalProjects:
+        type: integer
+        description: >-
+          The total number of results matching the query parameters.
+        minimum: 0
+        example: 212
     required:
       - capitalProjects
+      - totalProjects

--- a/openapi/paths/boroughs_{boroughId}_community-districts_{communityDistrictId}_capital-projects.yaml
+++ b/openapi/paths/boroughs_{boroughId}_community-districts_{communityDistrictId}_capital-projects.yaml
@@ -19,7 +19,5 @@ get:
             $ref: ../components/schemas/CapitalProjectPage.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml
     '500':
       $ref: ../components/responses/InternalServerError.yaml

--- a/openapi/paths/city-council-districts_{cityCouncilDistrictId}_capital-projects.yaml
+++ b/openapi/paths/city-council-districts_{cityCouncilDistrictId}_capital-projects.yaml
@@ -18,7 +18,5 @@ get:
             $ref: ../components/schemas/CapitalProjectPage.yaml
     '400':
       $ref: ../components/responses/BadRequest.yaml
-    '404':
-      $ref: ../components/responses/NotFound.yaml
     '500':
       $ref: ../components/responses/InternalServerError.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.4.5",
         "@nestjs/serve-static": "^4.0.0",
+        "cache-manager": "^6.4.1",
         "drizzle-orm": "^0.36.1",
         "immer": "^10.1.1",
         "joi": "^17.11.0",
@@ -2774,6 +2776,39 @@
         "jsep": "^0.4.0||^1.0.0"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keyv/serialize/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@kubb/cli": {
       "version": "2.28.4",
       "resolved": "https://registry.npmjs.org/@kubb/cli/-/cli-2.28.4.tgz",
@@ -3466,6 +3501,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -5516,7 +5564,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5756,6 +5803,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-manager": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-6.4.1.tgz",
+      "integrity": "sha512-DVy28v0FbeBp2SmFgKTa4o6muKP3T78Id0nht5D6mBAar1Nuc5z4nL6G0jpnEbYq8FS10dtrBNzQri5l9uJ/zA==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.3.1"
       }
     },
     "node_modules/call-bind": {
@@ -8561,6 +8617,16 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
@@ -9225,7 +9291,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10851,13 +10916,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.2.tgz",
+      "integrity": "sha512-Lji2XRxqqa5Wg+CHLVfFKBImfJZ4pCSccu9eVWK6w4c2SDFLd8JAn1zqTuSFnsxb7ope6rMsnIHfp+eBbRBRZQ==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.3"
       }
     },
     "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "kubb:generate": "kubb generate"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.4.5",
     "@nestjs/serve-static": "^4.0.0",
+    "cache-manager": "^6.4.1",
     "drizzle-orm": "^0.36.1",
     "immer": "^10.1.1",
     "joi": "^17.11.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { CapitalProjectModule } from "./capital-project/capital-project.module";
 import { CommunityDistrictModule } from "./community-district/community-district.module";
 import { CapitalCommitmentTypeModule } from "./capital-commitment-type/capital-commitment-type.module";
 import { AgencyBudgetModule } from "./agency-budget/agency-budget.module";
+import { CacheModule } from "@nestjs/cache-manager";
 
 @Module({
   imports: [
@@ -40,6 +41,10 @@ import { AgencyBudgetModule } from "./agency-budget/agency-budget.module";
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, "..", "openapi"),
       exclude: ["/api/(.*)"],
+    }),
+    CacheModule.register({
+      isGlobal: true,
+      ttl: 2.16e7,
     }),
     GlobalModule,
     AgencyModule,

--- a/src/borough/borough.controller.ts
+++ b/src/borough/borough.controller.ts
@@ -9,6 +9,7 @@ import {
   UsePipes,
 } from "@nestjs/common";
 import { BoroughService } from "./borough.service";
+import { CapitalProjectService } from "src/capital-project/capital-project.service";
 import { Response } from "express";
 import {
   FindCapitalProjectTilesByBoroughIdCommunityDistrictIdPathParams,
@@ -37,7 +38,10 @@ import { ZodTransformPipe } from "src/pipes/zod-transform-pipe";
 )
 @Controller("boroughs")
 export class BoroughController {
-  constructor(private readonly boroughService: BoroughService) {}
+  constructor(
+    private readonly boroughService: BoroughService,
+    private readonly capitalProjectService: CapitalProjectService,
+  ) {}
 
   @Get()
   async findMany() {
@@ -86,9 +90,10 @@ export class BoroughController {
     )
     queryParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
   ) {
-    return this.boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId(
-      { ...pathParams, ...queryParams },
-    );
+    return this.capitalProjectService.findMany({
+      ...queryParams,
+      communityDistrictCombinedId: `${pathParams.boroughId}${pathParams.communityDistrictId}`,
+    });
   }
 
   @UsePipes(

--- a/src/borough/borough.module.ts
+++ b/src/borough/borough.module.ts
@@ -3,10 +3,24 @@ import { BoroughService } from "./borough.service";
 import { BoroughController } from "./borough.controller";
 import { BoroughRepository } from "./borough.repository";
 import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
+import { CapitalProjectRepository } from "src/capital-project/capital-project.repository";
+import { CapitalProjectService } from "src/capital-project/capital-project.service";
+import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
+import { AgencyBudgetRepository } from "src/agency-budget/agency-budget.repository";
 
 @Module({
   exports: [BoroughService],
-  providers: [BoroughService, BoroughRepository, CommunityDistrictRepository],
+  providers: [
+    AgencyRepository,
+    AgencyBudgetRepository,
+    BoroughService,
+    BoroughRepository,
+    CapitalProjectService,
+    CapitalProjectRepository,
+    CityCouncilDistrictRepository,
+    CommunityDistrictRepository,
+  ],
   controllers: [BoroughController],
 })
 export class BoroughModule {}

--- a/src/borough/borough.repository.schema.ts
+++ b/src/borough/borough.repository.schema.ts
@@ -1,4 +1,3 @@
-import { capitalProjectSchema } from "src/gen";
 import {
   boroughEntitySchema,
   communityDistrictEntitySchema,
@@ -41,13 +40,6 @@ export type FindCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdRepo =
   z.infer<
     typeof findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdRepoSchema
   >;
-
-export const findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema =
-  z.array(capitalProjectSchema);
-
-export type FindCapitalProjectsByBoroughIdCommunityDistrictIdRepo = z.infer<
-  typeof findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema
->;
 
 export const findCapitalProjectTilesByBoroughIdCommunityDistrictIdRepoSchema =
   mvtEntitySchema;

--- a/src/borough/borough.repository.ts
+++ b/src/borough/borough.repository.ts
@@ -5,7 +5,6 @@ import {
   CheckByIdRepo,
   FindManyRepo,
   FindCommunityDistrictsByBoroughIdRepo,
-  FindCapitalProjectsByBoroughIdCommunityDistrictIdRepo,
   FindCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdRepo,
   FindCapitalProjectTilesByBoroughIdCommunityDistrictIdRepo,
 } from "./borough.repository.schema";
@@ -17,7 +16,6 @@ import {
 } from "src/schema";
 import { eq, sql, and, isNotNull, asc, sum } from "drizzle-orm";
 import {
-  CapitalProjectCategory,
   FindCapitalProjectTilesByBoroughIdCommunityDistrictIdPathParams,
   FindCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdPathParams,
 } from "src/gen";
@@ -96,49 +94,6 @@ export class BoroughRepository {
             eq(communityDistrict.id, communityDistrictId),
           ),
       });
-    } catch {
-      throw new DataRetrievalException();
-    }
-  }
-
-  async findCapitalProjectsByBoroughIdCommunityDistrictId({
-    boroughId,
-    communityDistrictId,
-    limit,
-    offset,
-  }: {
-    boroughId: string;
-    communityDistrictId: string;
-    limit: number;
-    offset: number;
-  }): Promise<FindCapitalProjectsByBoroughIdCommunityDistrictIdRepo> {
-    try {
-      return await this.db
-        .select({
-          id: capitalProject.id,
-          description: capitalProject.description,
-          managingCode: capitalProject.managingCode,
-          managingAgency: capitalProject.managingAgency,
-          maxDate: capitalProject.maxDate,
-          minDate: capitalProject.minDate,
-          category: sql<CapitalProjectCategory>`${capitalProject.category}`,
-        })
-        .from(capitalProject)
-        .leftJoin(
-          communityDistrict,
-          sql`
-          ST_Intersects(${communityDistrict.liFt}, ${capitalProject.liFtMPoly})
-          OR ST_Intersects(${communityDistrict.liFt}, ${capitalProject.liFtMPnt})`,
-        )
-        .where(
-          and(
-            eq(communityDistrict.boroughId, boroughId),
-            eq(communityDistrict.id, communityDistrictId),
-          ),
-        )
-        .limit(limit)
-        .offset(offset)
-        .orderBy(capitalProject.managingCode, capitalProject.id);
     } catch {
       throw new DataRetrievalException();
     }

--- a/src/borough/borough.service.spec.ts
+++ b/src/borough/borough.service.spec.ts
@@ -5,7 +5,6 @@ import { BoroughRepositoryMock } from "../../test/borough/borough.repository.moc
 import { Test } from "@nestjs/testing";
 import {
   findBoroughsQueryResponseSchema,
-  findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCapitalProjectTilesByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictsByBoroughIdQueryResponseSchema,
@@ -100,59 +99,6 @@ describe("Borough service unit", () => {
           },
         ),
       ).rejects.toThrow(ResourceNotFoundException);
-    });
-  });
-
-  describe("findCapitalProjectsByBoroughIdCommunityDistrictId", () => {
-    const { boroughId, id: communityDistrictId } =
-      boroughRepositoryMock.communityDistrictRepoMock
-        .checkByBoroughIdCommunityDistrictIdMocks[0];
-    it("service should return a capital projects compliant object using default query params", async () => {
-      const capitalProjects =
-        await boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId({
-          boroughId,
-          communityDistrictId,
-        });
-
-      expect(() =>
-        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
-          capitalProjects,
-        ),
-      ).not.toThrow();
-
-      const parsedBody =
-        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
-          capitalProjects,
-        );
-      expect(parsedBody.limit).toBe(20);
-      expect(parsedBody.offset).toBe(0);
-      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
-      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
-    });
-
-    it("service should return a list of capital projects by community district id, using the user specified limit and offset", async () => {
-      const capitalProjects =
-        await boroughService.findCapitalProjectsByBoroughIdCommunityDistrictId({
-          boroughId,
-          communityDistrictId,
-          limit: 10,
-          offset: 3,
-        });
-
-      expect(() =>
-        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
-          capitalProjects,
-        ),
-      ).not.toThrow();
-
-      const parsedBody =
-        findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema.parse(
-          capitalProjects,
-        );
-      expect(parsedBody.limit).toBe(10);
-      expect(parsedBody.offset).toBe(3);
-      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
-      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
     });
   });
 

--- a/src/borough/borough.service.ts
+++ b/src/borough/borough.service.ts
@@ -4,7 +4,6 @@ import { CommunityDistrictRepository } from "src/community-district/community-di
 import { ResourceNotFoundException } from "src/exception";
 import {
   FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams,
-  FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams,
   FindCapitalProjectTilesByBoroughIdCommunityDistrictIdPathParams,
 } from "src/gen";
 import { produce } from "immer";
@@ -63,40 +62,6 @@ export class BoroughService {
       id: `${communityDistrictGeoJson.boroughId}${communityDistrictGeoJson.id}`,
       properties,
       geometry,
-    };
-  }
-
-  async findCapitalProjectsByBoroughIdCommunityDistrictId({
-    boroughId,
-    communityDistrictId,
-    limit = 20,
-    offset = 0,
-  }: FindCapitalProjectsByBoroughIdCommunityDistrictIdPathParams &
-    FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams) {
-    const communityDistrictCheck =
-      await this.communityDistrictRepository.checkByBoroughIdCommunityDistrictId(
-        boroughId,
-        communityDistrictId,
-      );
-    if (communityDistrictCheck === undefined)
-      throw new ResourceNotFoundException();
-
-    const capitalProjects =
-      await this.boroughRepository.findCapitalProjectsByBoroughIdCommunityDistrictId(
-        {
-          boroughId,
-          communityDistrictId,
-          limit,
-          offset,
-        },
-      );
-
-    return {
-      limit,
-      offset,
-      total: capitalProjects.length,
-      order: "managingCode, capitalProjectId",
-      capitalProjects,
     };
   }
 

--- a/src/capital-project/capital-project.repository.schema.ts
+++ b/src/capital-project/capital-project.repository.schema.ts
@@ -14,6 +14,10 @@ export const findManyRepoSchema = z.array(capitalProjectEntitySchema);
 
 export type FindManyRepo = z.infer<typeof findManyRepoSchema>;
 
+export const findCountRepoSchema = z.number();
+
+export type FindCountRepo = z.infer<typeof findCountRepoSchema>;
+
 export const checkByManagingCodeCapitalProjectIdRepoSchema =
   capitalProjectEntitySchema.pick({
     id: true,

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -22,16 +22,43 @@ import {
   CheckByManagingCodeCapitalProjectIdRepo,
   FindByManagingCodeCapitalProjectIdRepo,
   FindCapitalCommitmentsByManagingCodeCapitalProjectIdRepo,
+  FindCountRepo,
   FindGeoJsonByManagingCodeCapitalProjectIdRepo,
   FindManyRepo,
   FindTilesRepo,
 } from "./capital-project.repository.schema";
+import { Cache } from "cache-manager";
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
 
 export class CapitalProjectRepository {
   constructor(
     @Inject(DB)
     private readonly db: DbType,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
+
+  #commitmentsTotalByCapitalProject = this.db
+    .$with("commitmentsTotalByCapitalProject")
+    .as(
+      this.db
+        .select({
+          managingCode: capitalCommitment.managingCode,
+          capitalProjectId: capitalCommitment.capitalProjectId,
+          value: sum(capitalCommitmentFund.value).mapWith(Number).as("value"),
+        })
+        .from(capitalCommitment)
+        .leftJoin(
+          capitalCommitmentFund,
+          and(
+            eq(capitalCommitment.id, capitalCommitmentFund.capitalCommitmentId),
+            eq(capitalCommitmentFund.category, "total"),
+          ),
+        )
+        .groupBy(
+          capitalCommitment.managingCode,
+          capitalCommitment.capitalProjectId,
+        ),
+    );
 
   async findMany({
     cityCouncilDistrictId,
@@ -55,34 +82,8 @@ export class CapitalProjectRepository {
     offset: number;
   }): Promise<FindManyRepo> {
     try {
-      const commitmentsTotalByCapitalProject = this.db
-        .$with("commitmentsTotalByCapitalProject")
-        .as(
-          this.db
-            .select({
-              managingCode: capitalCommitment.managingCode,
-              capitalProjectId: capitalCommitment.capitalProjectId,
-              value: sum(capitalCommitmentFund.value)
-                .mapWith(Number)
-                .as("value"),
-            })
-            .from(capitalCommitment)
-            .leftJoin(
-              capitalCommitmentFund,
-              and(
-                eq(
-                  capitalCommitment.id,
-                  capitalCommitmentFund.capitalCommitmentId,
-                ),
-                eq(capitalCommitmentFund.category, "total"),
-              ),
-            )
-            .groupBy(
-              capitalCommitment.managingCode,
-              capitalCommitment.capitalProjectId,
-            ),
-        );
-
+      const commitmentsTotalByCapitalProject =
+        this.#commitmentsTotalByCapitalProject;
       return await this.db
         .with(commitmentsTotalByCapitalProject)
         .select({
@@ -174,6 +175,122 @@ export class CapitalProjectRepository {
           capitalProject.minDate,
           capitalProject.category,
         );
+    } catch {
+      throw new DataRetrievalException();
+    }
+  }
+
+  async findCount(params: {
+    cityCouncilDistrictId: string | null;
+    communityDistrictId: string | null;
+    boroughId: string | null;
+    managingAgency: string | null;
+    agencyBudget: string | null;
+    commitmentsTotalMin: number | null;
+    commitmentsTotalMax: number | null;
+  }): Promise<FindCountRepo> {
+    const key = JSON.stringify({
+      ...params,
+      domain: "capitalProject",
+      function: "findCount",
+    });
+
+    const value: number | null = await this.cacheManager.get(key);
+    if (value !== null) {
+      return value;
+    }
+
+    const {
+      cityCouncilDistrictId,
+      communityDistrictId,
+      boroughId,
+      managingAgency,
+      agencyBudget,
+      commitmentsTotalMin,
+      commitmentsTotalMax,
+    } = params;
+    try {
+      const commitmentsTotalByCapitalProject =
+        this.#commitmentsTotalByCapitalProject;
+      const results = await this.db
+        .with(commitmentsTotalByCapitalProject)
+        .select({
+          total:
+            sql`COUNT(DISTINCT(${capitalProject.id}, ${capitalProject.managingCode}))`.mapWith(
+              Number,
+            ),
+        })
+        .from(capitalProject)
+        .leftJoin(
+          cityCouncilDistrict,
+          and(
+            sql`${cityCouncilDistrictId !== null} IS TRUE`,
+            or(
+              sql`ST_Intersects(${cityCouncilDistrict.liFt}, ${capitalProject.liFtMPoly})`,
+              sql`ST_Intersects(${cityCouncilDistrict.liFt}, ${capitalProject.liFtMPnt})`,
+            ),
+          ),
+        )
+        .leftJoin(
+          communityDistrict,
+          and(
+            sql`${communityDistrictId !== null && boroughId !== null} IS TRUE`,
+            or(
+              sql`ST_Intersects(${communityDistrict.liFt}, ${capitalProject.liFtMPoly})`,
+              sql`ST_Intersects(${communityDistrict.liFt}, ${capitalProject.liFtMPnt})`,
+            ),
+          ),
+        )
+        .leftJoin(
+          capitalCommitment,
+          and(
+            sql`${agencyBudget !== null} IS TRUE`,
+            eq(capitalProject.managingCode, capitalCommitment.managingCode),
+            eq(capitalProject.id, capitalCommitment.capitalProjectId),
+          ),
+        )
+        .leftJoin(
+          commitmentsTotalByCapitalProject,
+          and(
+            sql`${commitmentsTotalMin !== null || commitmentsTotalMax !== null} IS TRUE`,
+            eq(
+              commitmentsTotalByCapitalProject.capitalProjectId,
+              capitalProject.id,
+            ),
+            eq(
+              commitmentsTotalByCapitalProject.managingCode,
+              capitalProject.managingCode,
+            ),
+          ),
+        )
+        .where(
+          and(
+            cityCouncilDistrictId !== null
+              ? eq(cityCouncilDistrict.id, cityCouncilDistrictId)
+              : undefined,
+            communityDistrictId !== null && boroughId !== null
+              ? and(
+                  eq(communityDistrict.boroughId, boroughId),
+                  eq(communityDistrict.id, communityDistrictId),
+                )
+              : undefined,
+            managingAgency !== null
+              ? eq(capitalProject.managingAgency, managingAgency)
+              : undefined,
+            agencyBudget !== null
+              ? eq(capitalCommitment.budgetLineCode, agencyBudget)
+              : undefined,
+            commitmentsTotalMin !== null
+              ? gte(commitmentsTotalByCapitalProject.value, commitmentsTotalMin)
+              : undefined,
+            commitmentsTotalMax !== null
+              ? lte(commitmentsTotalByCapitalProject.value, commitmentsTotalMax)
+              : undefined,
+          ),
+        );
+      const { total } = results[0];
+      this.cacheManager.set(key, total);
+      return total;
     } catch {
       throw new DataRetrievalException();
     }

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -83,6 +83,7 @@ describe("CapitalProjectService", () => {
       expect(parsedBody.offset).toBe(0);
       expect(parsedBody.capitalProjects.length).toBe(8);
       expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.totalProjects).toBe(parsedBody.capitalProjects.length);
       expect(parsedBody.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -102,6 +103,9 @@ describe("CapitalProjectService", () => {
       expect(parsedResource.limit).toBe(20);
       expect(parsedResource.offset).toBe(0);
       expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.totalProjects).toBe(
+        parsedResource.capitalProjects.length,
+      );
       expect(parsedResource.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -134,6 +138,8 @@ describe("CapitalProjectService", () => {
       expect(parsedBody.limit).toBe(10);
       expect(parsedBody.offset).toBe(3);
       expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.capitalProjects.length).toBe(0);
+      expect(parsedBody.totalProjects).toBe(1);
       expect(parsedBody.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -153,6 +159,7 @@ describe("CapitalProjectService", () => {
       );
       expect(parsedBody.capitalProjects.length).toBe(7);
       expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.totalProjects).toBe(parsedBody.capitalProjects.length);
       expect(parsedBody.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -182,6 +189,9 @@ describe("CapitalProjectService", () => {
       expect(parsedResource.offset).toBe(0);
       expect(parsedResource.capitalProjects.length).toBe(1);
       expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.totalProjects).toBe(
+        parsedResource.capitalProjects.length,
+      );
       expect(parsedResource.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -210,6 +220,9 @@ describe("CapitalProjectService", () => {
       expect(parsedResource.offset).toBe(0);
       expect(parsedResource.capitalProjects.length).toBe(8);
       expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.totalProjects).toBe(
+        parsedResource.capitalProjects.length,
+      );
       expect(parsedResource.order).toBe("managingCode, capitalProjectId");
     });
 
@@ -228,6 +241,9 @@ describe("CapitalProjectService", () => {
       expect(parsedResource.offset).toBe(0);
       expect(parsedResource.capitalProjects.length).toBe(8);
       expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
+      expect(parsedResource.totalProjects).toBe(
+        parsedResource.capitalProjects.length,
+      );
       expect(parsedResource.order).toBe("managingCode, capitalProjectId");
     });
 

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -98,7 +98,7 @@ export class CapitalProjectService {
     if (checkedList.some((result) => result === undefined))
       throw new InvalidRequestParameterException();
 
-    const capitalProjects = await this.capitalProjectRepository.findMany({
+    const capitalProjectsPromise = this.capitalProjectRepository.findMany({
       cityCouncilDistrictId,
       boroughId,
       communityDistrictId,
@@ -110,11 +110,27 @@ export class CapitalProjectService {
       offset,
     });
 
+    const totalProjectsPromise = this.capitalProjectRepository.findCount({
+      cityCouncilDistrictId,
+      boroughId,
+      communityDistrictId,
+      managingAgency,
+      agencyBudget,
+      commitmentsTotalMin: min,
+      commitmentsTotalMax: max,
+    });
+
+    const [capitalProjects, totalProjects] = await Promise.all([
+      capitalProjectsPromise,
+      totalProjectsPromise,
+    ]);
+
     return {
       capitalProjects,
       limit,
       offset,
       total: capitalProjects.length,
+      totalProjects,
       order: "managingCode, capitalProjectId",
     };
   }

--- a/src/city-council-district/city-council-district.controller.ts
+++ b/src/city-council-district/city-council-district.controller.ts
@@ -29,6 +29,7 @@ import {
   findCapitalProjectsByCityCouncilIdPathParamsSchema,
   findCapitalProjectsByCityCouncilIdQueryParamsSchema,
 } from "src/gen";
+import { CapitalProjectService } from "src/capital-project/capital-project.service";
 
 @UseFilters(
   InternalServerErrorExceptionFilter,
@@ -39,6 +40,7 @@ import {
 export class CityCouncilDistrictController {
   constructor(
     private readonly cityCouncilDistrictService: CityCouncilDistrictService,
+    private readonly capitalProjectService: CapitalProjectService,
   ) {}
 
   @Get()
@@ -101,7 +103,7 @@ export class CityCouncilDistrictController {
     @Param() pathParams: FindCapitalProjectsByCityCouncilIdPathParams,
     @Query() queryParams: FindCapitalProjectsByCityCouncilIdQueryParams,
   ) {
-    return await this.cityCouncilDistrictService.findCapitalProjectsById({
+    return await this.capitalProjectService.findMany({
       ...pathParams,
       ...queryParams,
     });

--- a/src/city-council-district/city-council-district.module.ts
+++ b/src/city-council-district/city-council-district.module.ts
@@ -2,10 +2,23 @@ import { Module } from "@nestjs/common";
 import { CityCouncilDistrictService } from "./city-council-district.service";
 import { CityCouncilDistrictController } from "./city-council-district.controller";
 import { CityCouncilDistrictRepository } from "./city-council-district.repository";
+import { AgencyRepository } from "src/agency/agency.repository";
+import { AgencyBudgetRepository } from "src/agency-budget/agency-budget.repository";
+import { CapitalProjectRepository } from "src/capital-project/capital-project.repository";
+import { CapitalProjectService } from "src/capital-project/capital-project.service";
+import { CommunityDistrictRepository } from "src/community-district/community-district.repository";
 
 @Module({
   exports: [CityCouncilDistrictService],
-  providers: [CityCouncilDistrictService, CityCouncilDistrictRepository],
+  providers: [
+    AgencyRepository,
+    AgencyBudgetRepository,
+    CapitalProjectRepository,
+    CapitalProjectService,
+    CityCouncilDistrictService,
+    CityCouncilDistrictRepository,
+    CommunityDistrictRepository,
+  ],
   controllers: [CityCouncilDistrictController],
 })
 export class CityCouncilDistrictModule {}

--- a/src/city-council-district/city-council-district.repository.schema.ts
+++ b/src/city-council-district/city-council-district.repository.schema.ts
@@ -1,6 +1,5 @@
 import { mvtEntitySchema } from "src/schema/mvt";
 import {
-  capitalProjectEntitySchema,
   cityCouncilDistrictEntitySchema,
   MultiPolygonSchema,
 } from "src/schema";
@@ -39,11 +38,3 @@ export const checkByIdRepoSchema = cityCouncilDistrictEntitySchema.pick({
 });
 
 export type CheckByIdRepo = z.infer<typeof checkByIdRepoSchema>;
-
-export const findCapitalProjectsByCityCouncilDistrictIdRepoSchema = z.array(
-  capitalProjectEntitySchema,
-);
-
-export type FindCapitalProjectsByCityCouncilDistrictIdRepo = z.infer<
-  typeof findCapitalProjectsByCityCouncilDistrictIdRepoSchema
->;

--- a/src/city-council-district/city-council-district.repository.ts
+++ b/src/city-council-district/city-council-district.repository.ts
@@ -5,12 +5,10 @@ import {
   CheckByIdRepo,
   FindManyRepo,
   FindTilesRepo,
-  FindCapitalProjectsByCityCouncilDistrictIdRepo,
   FindGeoJsonByIdRepo,
   FindCapitalProjectTilesByCityCouncilDistrictIdRepo,
 } from "./city-council-district.repository.schema";
 import {
-  CapitalProjectCategory,
   FindCapitalProjectTilesByCityCouncilDistrictIdPathParams,
   FindCityCouncilDistrictGeoJsonByCityCouncilDistrictIdPathParams,
   FindCityCouncilDistrictTilesPathParams,
@@ -226,42 +224,6 @@ export class CityCouncilDistrictRepository {
       const [fill, label] = await Promise.all([dataFill, dataLabel]);
 
       return Buffer.concat([fill[0].mvt, label[0].mvt] as Uint8Array[]);
-    } catch {
-      throw new DataRetrievalException();
-    }
-  }
-
-  async findCapitalProjectsById({
-    limit,
-    offset,
-    cityCouncilDistrictId,
-  }: {
-    limit: number;
-    offset: number;
-    cityCouncilDistrictId: string;
-  }): Promise<FindCapitalProjectsByCityCouncilDistrictIdRepo> {
-    try {
-      return await this.db
-        .select({
-          id: capitalProject.id,
-          description: capitalProject.description,
-          managingCode: capitalProject.managingCode,
-          managingAgency: capitalProject.managingAgency,
-          maxDate: capitalProject.maxDate,
-          minDate: capitalProject.minDate,
-          category: sql<CapitalProjectCategory>`${capitalProject.category}`,
-        })
-        .from(capitalProject)
-        .leftJoin(
-          cityCouncilDistrict,
-          sql`
-            ST_Intersects(${cityCouncilDistrict.liFt}, ${capitalProject.liFtMPoly})
-            OR ST_Intersects(${cityCouncilDistrict.liFt}, ${capitalProject.liFtMPnt})`,
-        )
-        .where(eq(cityCouncilDistrict.id, cityCouncilDistrictId))
-        .limit(limit)
-        .offset(offset)
-        .orderBy(capitalProject.managingCode, capitalProject.id);
     } catch {
       throw new DataRetrievalException();
     }

--- a/src/city-council-district/city-council-district.service.spec.ts
+++ b/src/city-council-district/city-council-district.service.spec.ts
@@ -3,7 +3,6 @@ import { Test } from "@nestjs/testing";
 import { CityCouncilDistrictRepository } from "./city-council-district.repository";
 import {
   findCityCouncilDistrictTilesQueryResponseSchema,
-  findCapitalProjectsByCityCouncilIdQueryResponseSchema,
   findCityCouncilDistrictsQueryResponseSchema,
   findCityCouncilDistrictGeoJsonByCityCouncilDistrictIdQueryResponseSchema,
   findCapitalProjectTilesByCityCouncilDistrictIdQueryResponseSchema,
@@ -95,52 +94,6 @@ describe("City Council District service unit", () => {
           mvt,
         ),
       ).not.toThrow();
-    });
-  });
-
-  describe("findCapitalProjectsByCityCouncilId", () => {
-    it("service should return a list of capital projects by city council district id, using the default limit and offset", async () => {
-      const { id } =
-        cityCouncilDistrictRepositoryMock.checkCityCouncilDistrictByIdMocks[0];
-
-      const resource = await cityCouncilDistrictService.findCapitalProjectsById(
-        {
-          cityCouncilDistrictId: id,
-        },
-      );
-
-      expect(() =>
-        findCapitalProjectsByCityCouncilIdQueryResponseSchema.parse(resource),
-      ).not.toThrow();
-      const parsedResource =
-        findCapitalProjectsByCityCouncilIdQueryResponseSchema.parse(resource);
-      expect(parsedResource.limit).toBe(20);
-      expect(parsedResource.offset).toBe(0);
-      expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
-      expect(parsedResource.order).toBe("managingCode, capitalProjectId");
-    });
-
-    it("service should return a list of capital projects by city council district id, using the user specified limit and offset", async () => {
-      const { id } =
-        cityCouncilDistrictRepositoryMock.checkCityCouncilDistrictByIdMocks[0];
-
-      const resource = await cityCouncilDistrictService.findCapitalProjectsById(
-        {
-          cityCouncilDistrictId: id,
-          limit: 10,
-          offset: 3,
-        },
-      );
-
-      expect(() =>
-        findCapitalProjectsByCityCouncilIdQueryResponseSchema.parse(resource),
-      ).not.toThrow();
-      const parsedResource =
-        findCapitalProjectsByCityCouncilIdQueryResponseSchema.parse(resource);
-      expect(parsedResource.limit).toBe(10);
-      expect(parsedResource.offset).toBe(3);
-      expect(parsedResource.total).toBe(parsedResource.capitalProjects.length);
-      expect(parsedResource.order).toBe("managingCode, capitalProjectId");
     });
   });
 });

--- a/src/city-council-district/city-council-district.service.ts
+++ b/src/city-council-district/city-council-district.service.ts
@@ -2,9 +2,6 @@ import { Inject, Injectable } from "@nestjs/common";
 import { CityCouncilDistrictRepository } from "./city-council-district.repository";
 import { ResourceNotFoundException } from "src/exception";
 import {
-  FindCapitalProjectsByCityCouncilIdPathParams,
-  FindCapitalProjectsByCityCouncilIdQueryParams,
-  FindCapitalProjectsByCityCouncilIdQueryResponse,
   FindCapitalProjectTilesByCityCouncilDistrictIdPathParams,
   FindCityCouncilDistrictGeoJsonByCityCouncilDistrictIdPathParams,
   FindCityCouncilDistrictTilesPathParams,
@@ -69,35 +66,5 @@ export class CityCouncilDistrictService {
     return this.cityCouncilDistrictRepository.findCapitalProjectTilesByCityCouncilDistrictId(
       params,
     );
-  }
-
-  async findCapitalProjectsById({
-    limit = 20,
-    offset = 0,
-    cityCouncilDistrictId,
-  }: FindCapitalProjectsByCityCouncilIdPathParams &
-    FindCapitalProjectsByCityCouncilIdQueryParams): Promise<FindCapitalProjectsByCityCouncilIdQueryResponse> {
-    const cityCouncilDistrictCheck =
-      await this.cityCouncilDistrictRepository.checkCityCouncilDistrictById(
-        cityCouncilDistrictId,
-      );
-
-    if (cityCouncilDistrictCheck === undefined)
-      throw new ResourceNotFoundException();
-
-    const capitalProjects =
-      await this.cityCouncilDistrictRepository.findCapitalProjectsById({
-        limit,
-        offset,
-        cityCouncilDistrictId,
-      });
-
-    return {
-      limit,
-      offset,
-      total: capitalProjects.length,
-      order: "managingCode, capitalProjectId",
-      capitalProjects,
-    };
   }
 }

--- a/src/gen/schemas/CapitalProjectPage.json
+++ b/src/gen/schemas/CapitalProjectPage.json
@@ -96,9 +96,15 @@
             ],
             "x-readme-ref-name": "CapitalProject"
           }
+        },
+        "totalProjects": {
+          "type": "integer",
+          "description": "The total number of results matching the query parameters.",
+          "minimum": 0,
+          "example": 212
         }
       },
-      "required": ["capitalProjects"]
+      "required": ["capitalProjects", "totalProjects"]
     }
   ],
   "x-readme-ref-name": "CapitalProjectPage"

--- a/src/gen/types/CapitalProjectPage.ts
+++ b/src/gen/types/CapitalProjectPage.ts
@@ -6,4 +6,9 @@ export type CapitalProjectPage = Page & {
    * @type array
    */
   capitalProjects: CapitalProject[];
+  /**
+   * @description The total number of results matching the query parameters.
+   * @type integer
+   */
+  totalProjects: number;
 };

--- a/src/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
+++ b/src/gen/types/FindCapitalProjectsByBoroughIdCommunityDistrictId.ts
@@ -35,10 +35,6 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictId200 =
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByBoroughIdCommunityDistrictId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByBoroughIdCommunityDistrictId500 = Error;
@@ -53,6 +49,5 @@ export type FindCapitalProjectsByBoroughIdCommunityDistrictIdQuery = {
   QueryParams: FindCapitalProjectsByBoroughIdCommunityDistrictIdQueryParams;
   Errors:
     | FindCapitalProjectsByBoroughIdCommunityDistrictId400
-    | FindCapitalProjectsByBoroughIdCommunityDistrictId404
     | FindCapitalProjectsByBoroughIdCommunityDistrictId500;
 };

--- a/src/gen/types/FindCapitalProjectsByCityCouncilId.ts
+++ b/src/gen/types/FindCapitalProjectsByCityCouncilId.ts
@@ -29,10 +29,6 @@ export type FindCapitalProjectsByCityCouncilId200 = CapitalProjectPage;
  */
 export type FindCapitalProjectsByCityCouncilId400 = Error;
 /**
- * @description Requested resource does not exist or is not available
- */
-export type FindCapitalProjectsByCityCouncilId404 = Error;
-/**
  * @description Server side error
  */
 export type FindCapitalProjectsByCityCouncilId500 = Error;
@@ -47,6 +43,5 @@ export type FindCapitalProjectsByCityCouncilIdQuery = {
   QueryParams: FindCapitalProjectsByCityCouncilIdQueryParams;
   Errors:
     | FindCapitalProjectsByCityCouncilId400
-    | FindCapitalProjectsByCityCouncilId404
     | FindCapitalProjectsByCityCouncilId500;
 };

--- a/src/gen/zod/capitalProjectPageSchema.ts
+++ b/src/gen/zod/capitalProjectPageSchema.ts
@@ -5,5 +5,12 @@ import { z } from "zod";
 export const capitalProjectPageSchema = z
   .lazy(() => pageSchema)
   .and(
-    z.object({ capitalProjects: z.array(z.lazy(() => capitalProjectSchema)) }),
+    z.object({
+      capitalProjects: z.array(z.lazy(() => capitalProjectSchema)),
+      totalProjects: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .describe("The total number of results matching the query parameters."),
+    }),
   );

--- a/src/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
+++ b/src/gen/zod/findCapitalProjectsByBoroughIdCommunityDistrictIdSchema.ts
@@ -51,11 +51,6 @@ export const findCapitalProjectsByBoroughIdCommunityDistrictId200Schema =
 export const findCapitalProjectsByBoroughIdCommunityDistrictId400Schema =
   z.lazy(() => errorSchema);
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByBoroughIdCommunityDistrictId404Schema =
-  z.lazy(() => errorSchema);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByBoroughIdCommunityDistrictId500Schema =

--- a/src/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
+++ b/src/gen/zod/findCapitalProjectsByCityCouncilIdSchema.ts
@@ -43,12 +43,6 @@ export const findCapitalProjectsByCityCouncilId400Schema = z.lazy(
   () => errorSchema,
 );
 /**
- * @description Requested resource does not exist or is not available
- */
-export const findCapitalProjectsByCityCouncilId404Schema = z.lazy(
-  () => errorSchema,
-);
-/**
  * @description Server side error
  */
 export const findCapitalProjectsByCityCouncilId500Schema = z.lazy(

--- a/src/gen/zod/operations.ts
+++ b/src/gen/zod/operations.ts
@@ -30,7 +30,6 @@ import {
 import {
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-  findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdPathParamsSchema,
   findCapitalProjectsByBoroughIdCommunityDistrictIdQueryParamsSchema,
@@ -100,7 +99,6 @@ import {
 import {
   findCapitalProjectsByCityCouncilIdQueryResponseSchema,
   findCapitalProjectsByCityCouncilId400Schema,
-  findCapitalProjectsByCityCouncilId404Schema,
   findCapitalProjectsByCityCouncilId500Schema,
   findCapitalProjectsByCityCouncilIdPathParamsSchema,
   findCapitalProjectsByCityCouncilIdQueryParamsSchema,
@@ -294,14 +292,12 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
       default:
         findCapitalProjectsByBoroughIdCommunityDistrictIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByBoroughIdCommunityDistrictId400Schema,
-      404: findCapitalProjectsByBoroughIdCommunityDistrictId404Schema,
       500: findCapitalProjectsByBoroughIdCommunityDistrictId500Schema,
     },
   },
@@ -509,13 +505,11 @@ export const operations = {
     responses: {
       200: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
       default: findCapitalProjectsByCityCouncilIdQueryResponseSchema,
     },
     errors: {
       400: findCapitalProjectsByCityCouncilId400Schema,
-      404: findCapitalProjectsByCityCouncilId404Schema,
       500: findCapitalProjectsByCityCouncilId500Schema,
     },
   },

--- a/test/borough/borough.repository.mock.ts
+++ b/test/borough/borough.repository.mock.ts
@@ -2,7 +2,6 @@ import {
   findManyRepoSchema,
   checkByIdRepoSchema,
   findCommunityDistrictsByBoroughIdRepoSchema,
-  findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema,
   communityDistrictGeoJsonEntitySchema,
   findCapitalProjectTilesByBoroughIdCommunityDistrictIdRepoSchema,
 } from "src/borough/borough.repository.schema";
@@ -47,19 +46,6 @@ export class BoroughRepositoryMock {
     return results === undefined ? [] : results[id];
   }
 
-  get findCapitalProjectsByBoroughIdCommunityDistrictIdMocks() {
-    return this.communityDistrictRepoMock.checkByBoroughIdCommunityDistrictIdMocks.map(
-      (communityDistrict) => {
-        return {
-          [`${communityDistrict.boroughId}${communityDistrict.id}`]:
-            generateMock(
-              findCapitalProjectsByBoroughIdCommunityDistrictIdRepoSchema,
-            ),
-        };
-      },
-    );
-  }
-
   findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdMocks = Array.from(
     Array(this.numberOfMocks),
     (_, seed) =>
@@ -73,20 +59,6 @@ export class BoroughRepositoryMock {
     return this.findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdMocks.find(
       (row) => row.id === communityDistrictId && row.boroughId === boroughId,
     );
-  }
-
-  async findCapitalProjectsByBoroughIdCommunityDistrictId(
-    boroughId: string,
-    communityDistrictId: string,
-  ) {
-    const results =
-      this.findCapitalProjectsByBoroughIdCommunityDistrictIdMocks.find(
-        (capitalProjects) =>
-          `${boroughId}${communityDistrictId}` in capitalProjects,
-      );
-    return results == undefined
-      ? []
-      : results[`${boroughId}${communityDistrictId}`];
   }
 
   findCapitalProjectTilesByBoroughIdCommunityDistrictIdMock = generateMock(

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -28,14 +28,14 @@ describe("Capital Projects", () => {
   let app: INestApplication;
 
   const agencyRepositoryMock = new AgencyRepositoryMock();
-  const cityCouncilDistrictRepository = new CityCouncilDistrictRepositoryMock();
-  const communityDistrictRepository = new CommunityDistrictRepositoryMock();
   const agencyBudgetRepositoryMock = new AgencyBudgetRepositoryMock();
-
+  const cityCouncilDistrictRepositoryMock =
+    new CityCouncilDistrictRepositoryMock();
+  const communityDistrictRepositoryMock = new CommunityDistrictRepositoryMock();
   const capitalProjectRepositoryMock = new CapitalProjectRepositoryMock(
     agencyRepositoryMock,
-    cityCouncilDistrictRepository,
-    communityDistrictRepository,
+    cityCouncilDistrictRepositoryMock,
+    communityDistrictRepositoryMock,
     agencyBudgetRepositoryMock,
   );
 
@@ -46,9 +46,9 @@ describe("Capital Projects", () => {
       .overrideProvider(CapitalProjectRepository)
       .useValue(capitalProjectRepositoryMock)
       .overrideProvider(CityCouncilDistrictRepository)
-      .useValue(cityCouncilDistrictRepository)
+      .useValue(cityCouncilDistrictRepositoryMock)
       .overrideProvider(CommunityDistrictRepository)
-      .useValue(communityDistrictRepository)
+      .useValue(communityDistrictRepositoryMock)
       .overrideProvider(AgencyRepository)
       .useValue(agencyRepositoryMock)
       .overrideProvider(AgencyBudgetRepository)

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -112,7 +112,7 @@ export class CapitalProjectRepositoryMock {
     ];
   }
 
-  async findMany({
+  async findAll({
     managingAgency,
     boroughId,
     communityDistrictId,
@@ -120,8 +120,6 @@ export class CapitalProjectRepositoryMock {
     agencyBudget,
     commitmentsTotalMin,
     commitmentsTotalMax,
-    limit,
-    offset,
   }: {
     managingAgency: string | null;
     cityCouncilDistrictId: string | null;
@@ -130,11 +128,9 @@ export class CapitalProjectRepositoryMock {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
-    limit: number;
-    offset: number;
   }) {
-    return this.findManyMocks
-      .reduce((acc: FindManyRepo, [criteria, capitalProjects]) => {
+    return this.findManyMocks.reduce(
+      (acc: FindManyRepo, [criteria, capitalProjects]) => {
         if (
           managingAgency !== null &&
           criteria.managingAgency !== managingAgency
@@ -169,8 +165,71 @@ export class CapitalProjectRepositoryMock {
         )
           return acc;
         return acc.concat(capitalProjects);
-      }, [])
-      .slice(offset, limit + offset);
+      },
+      [],
+    );
+  }
+
+  async findMany({
+    managingAgency,
+    boroughId,
+    communityDistrictId,
+    cityCouncilDistrictId,
+    agencyBudget,
+    commitmentsTotalMin,
+    commitmentsTotalMax,
+    limit,
+    offset,
+  }: {
+    managingAgency: string | null;
+    cityCouncilDistrictId: string | null;
+    communityDistrictId: string | null;
+    boroughId: string | null;
+    agencyBudget: string | null;
+    commitmentsTotalMin: number | null;
+    commitmentsTotalMax: number | null;
+    limit: number;
+    offset: number;
+  }) {
+    const results = await this.findAll({
+      managingAgency,
+      boroughId,
+      communityDistrictId,
+      cityCouncilDistrictId,
+      agencyBudget,
+      commitmentsTotalMin,
+      commitmentsTotalMax,
+    });
+    return results.slice(offset, limit + offset);
+  }
+
+  async findCount({
+    managingAgency,
+    boroughId,
+    communityDistrictId,
+    cityCouncilDistrictId,
+    agencyBudget,
+    commitmentsTotalMin,
+    commitmentsTotalMax,
+  }: {
+    managingAgency: string | null;
+    cityCouncilDistrictId: string | null;
+    communityDistrictId: string | null;
+    boroughId: string | null;
+    agencyBudget: string | null;
+    commitmentsTotalMin: number | null;
+    commitmentsTotalMax: number | null;
+  }) {
+    const results = await this.findAll({
+      managingAgency,
+      boroughId,
+      communityDistrictId,
+      cityCouncilDistrictId,
+      agencyBudget,
+      commitmentsTotalMin,
+      commitmentsTotalMax,
+    });
+    return results.length;
   }
 
   checkByManagingCodeCapitalProjectIdMocks = Array.from(Array(5), (_, seed) =>

--- a/test/city-council-district/city-council-district.repository.mock.ts
+++ b/test/city-council-district/city-council-district.repository.mock.ts
@@ -2,7 +2,6 @@ import {
   findManyRepoSchema,
   findTilesRepoSchema,
   checkByIdRepoSchema,
-  findCapitalProjectsByCityCouncilDistrictIdRepoSchema,
   findGeoJsonByIdRepoSchema,
   findCapitalProjectTilesByCityCouncilDistrictIdRepoSchema,
 } from "src/city-council-district/city-council-district.repository.schema";
@@ -57,22 +56,6 @@ export class CityCouncilDistrictRepositoryMock {
     return this.checkCityCouncilDistrictByIdMocks.find((row) => row.id === id);
   }
 
-  findCapitalProjectsByIdMocks = this.checkCityCouncilDistrictByIdMocks.map(
-    (checkCityCouncilDistrict) => {
-      return {
-        [checkCityCouncilDistrict.id]: generateMock(
-          findCapitalProjectsByCityCouncilDistrictIdRepoSchema,
-          {
-            stringMap: {
-              minDate: () => "2018-01-01",
-              maxDate: () => "2045-12-31",
-            },
-          },
-        ),
-      };
-    },
-  );
-
   findCapitalProjectTilesByCityCouncilDistrictIdMock = generateMock(
     findCapitalProjectTilesByCityCouncilDistrictIdRepoSchema,
   );
@@ -90,24 +73,5 @@ export class CityCouncilDistrictRepositoryMock {
    */
   async findCapitalProjectTilesByCityCouncilDistrictId() {
     return this.findCapitalProjectTilesByCityCouncilDistrictIdMock;
-  }
-
-  async findCapitalProjectsById({
-    limit,
-    offset,
-    cityCouncilDistrictId,
-  }: {
-    limit: number;
-    offset: number;
-    cityCouncilDistrictId: string;
-  }) {
-    const results = this.findCapitalProjectsByIdMocks.find((ccdIdToCps) => {
-      return cityCouncilDistrictId in ccdIdToCps;
-    });
-
-    const capitalProjects =
-      results === undefined ? [] : results[cityCouncilDistrictId];
-
-    return capitalProjects.slice(offset, limit + offset);
   }
 }


### PR DESCRIPTION
Add totalProjects field to indicate how many
capital projects match the requested filters

Add in-memory cache

Cache value of totalProjects

closes #413

## Additional context
The exising community district and city council district endpoints for capital projects also depended on the `Page` schema. Updating the schema for one Capital Project endpoint meant the documentation for every capital project endpoint promised a `totalProjects` field. The simplest way to fullfil this promise was to reuse the capital project service in every controller. We then removed the services and controllers that were no longer used.

This also changed the `404` to `400`s when looking for non-exisiting districts 