### PR TITLE
Bugfix: commitment totals encoded as string

### DIFF
--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -448,9 +448,11 @@ export class CapitalProjectRepository {
           managingAgency: sql`${capitalProject.managingAgency}`.as(
             `managingAgency`,
           ),
-          commitmentsTotal: sum(capitalCommitmentFund.value).as(
-            "commitmentsTotal",
-          ),
+          commitmentsTotal:
+            // numeric type is econded as string, double precision type is encoded in mvt as number
+            sql`SUM(${capitalCommitmentFund.value})::double precision`
+              .mapWith(Number)
+              .as("commitmentsTotal"),
           agencyBudgets: sql<
             Array<string>
           >`ARRAY_TO_JSON(ARRAY_AGG(DISTINCT ${capitalCommitment.budgetLineCode}))`.as(


### PR DESCRIPTION
Coerce commitment totals from numeric to double precision type to encode them in mvts as numbers instead of strings

closes #440