### PR TITLE
461 Filter of whether a capital project is mapped

### DIFF
--- a/openapi/components/parameters/isMappedQueryParam.yaml
+++ b/openapi/components/parameters/isMappedQueryParam.yaml
@@ -1,0 +1,9 @@
+name: isMapped
+required: false
+in: query
+schema:
+  type: boolean
+  example: true
+description: >-
+  Used to filter whether a capital project has associated
+  geographic coordinates.

--- a/openapi/paths/capital-projects.yaml
+++ b/openapi/paths/capital-projects.yaml
@@ -10,6 +10,7 @@ get:
     - $ref: ../components/parameters/agencyBudgetParam.yaml
     - $ref: ../components/parameters/commitmentsTotalMinQueryParam.yaml
     - $ref: ../components/parameters/commitmentsTotalMaxQueryParam.yaml
+    - $ref: ../components/parameters/isMappedQueryParam.yaml
     - $ref: ../components/parameters/limitParam.yaml
     - $ref: ../components/parameters/offsetParam.yaml
   responses:

--- a/src/capital-project/capital-project.controller.ts
+++ b/src/capital-project/capital-project.controller.ts
@@ -48,6 +48,7 @@ export class CapitalProjectController {
       communityDistrictCombinedId: queryParams.communityDistrictId,
       managingAgency: queryParams.managingAgency,
       agencyBudget: queryParams.agencyBudget,
+      isMapped: queryParams.isMapped,
       commitmentsTotalMin: queryParams.commitmentsTotalMin,
       commitmentsTotalMax: queryParams.commitmentsTotalMax,
     });

--- a/src/capital-project/capital-project.repository.ts
+++ b/src/capital-project/capital-project.repository.ts
@@ -1,5 +1,16 @@
 import { Inject } from "@nestjs/common";
-import { isNotNull, sql, and, eq, sum, asc, gte, lte, or } from "drizzle-orm";
+import {
+  isNotNull,
+  isNull,
+  sql,
+  and,
+  eq,
+  sum,
+  asc,
+  gte,
+  lte,
+  or,
+} from "drizzle-orm";
 import { DataRetrievalException } from "src/exception";
 import {
   CapitalProjectCategory,
@@ -73,6 +84,7 @@ export class CapitalProjectRepository {
     agencyBudget,
     commitmentsTotalMin,
     commitmentsTotalMax,
+    isMapped,
     limit,
     offset,
   }: {
@@ -83,6 +95,7 @@ export class CapitalProjectRepository {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
+    isMapped: boolean | null;
     limit: number;
     offset: number;
   }): Promise<FindManyRepo> {
@@ -166,6 +179,18 @@ export class CapitalProjectRepository {
             commitmentsTotalMax !== null
               ? lte(commitmentsTotalByCapitalProject.value, commitmentsTotalMax)
               : undefined,
+            isMapped === true
+              ? or(
+                  isNotNull(capitalProject.liFtMPoly),
+                  isNotNull(capitalProject.liFtMPnt),
+                )
+              : undefined,
+            isMapped === false
+              ? and(
+                  isNull(capitalProject.liFtMPoly),
+                  isNull(capitalProject.liFtMPnt),
+                )
+              : undefined,
           ),
         )
         .limit(limit)
@@ -193,6 +218,7 @@ export class CapitalProjectRepository {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
+    isMapped: boolean | null;
   }): Promise<FindCountRepo> {
     const key = JSON.stringify({
       ...params,
@@ -213,6 +239,7 @@ export class CapitalProjectRepository {
       agencyBudget,
       commitmentsTotalMin,
       commitmentsTotalMax,
+      isMapped,
     } = params;
     try {
       const commitmentsTotalByCapitalProject =
@@ -290,6 +317,18 @@ export class CapitalProjectRepository {
               : undefined,
             commitmentsTotalMax !== null
               ? lte(commitmentsTotalByCapitalProject.value, commitmentsTotalMax)
+              : undefined,
+            isMapped === true
+              ? or(
+                  isNotNull(capitalProject.liFtMPoly),
+                  isNotNull(capitalProject.liFtMPnt),
+                )
+              : undefined,
+            isMapped === false
+              ? and(
+                  isNull(capitalProject.liFtMPoly),
+                  isNull(capitalProject.liFtMPnt),
+                )
               : undefined,
           ),
         );

--- a/src/capital-project/capital-project.service.spec.ts
+++ b/src/capital-project/capital-project.service.spec.ts
@@ -265,6 +265,79 @@ describe("CapitalProjectService", () => {
         }),
       ).rejects.toThrow(InvalidRequestParameterException);
     });
+
+    it("should return both mapped and unmapped capital projects when no isMapped value is provided", async () => {
+      const capitalProjectsResponse = await capitalProjectService.findMany({});
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(capitalProjectsResponse),
+      ).not.toThrow();
+
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        capitalProjectsResponse,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.capitalProjects.length).toBe(9);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.totalProjects).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should return only capital projects with non-null geometries when isMapped is true", async () => {
+      const capitalProjectsResponse = await capitalProjectService.findMany({
+        isMapped: true,
+      });
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(capitalProjectsResponse),
+      ).not.toThrow();
+
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        capitalProjectsResponse,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.capitalProjects.length).toBe(4);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.totalProjects).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should return only capital projects with null geometries when isMapped is false", async () => {
+      const capitalProjectsResponse = await capitalProjectService.findMany({
+        isMapped: false,
+      });
+      expect(() =>
+        findCapitalProjectsQueryResponseSchema.parse(capitalProjectsResponse),
+      ).not.toThrow();
+
+      const parsedBody = findCapitalProjectsQueryResponseSchema.parse(
+        capitalProjectsResponse,
+      );
+      expect(parsedBody.limit).toBe(20);
+      expect(parsedBody.offset).toBe(0);
+      expect(parsedBody.capitalProjects.length).toBe(5);
+      expect(parsedBody.total).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.totalProjects).toBe(parsedBody.capitalProjects.length);
+      expect(parsedBody.order).toBe("managingCode, capitalProjectId");
+    });
+
+    it("should return a InvalidRequestParameterException error when both a city council district id and isMapped are provided", async () => {
+      expect(
+        capitalProjectService.findMany({
+          cityCouncilDistrictId: "50",
+          isMapped: true,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
+    it("should return a InvalidRequestParameterException error when both a community district id and isMapped are provided", async () => {
+      expect(
+        capitalProjectService.findMany({
+          communityDistrictCombinedId: "101",
+          isMapped: true,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
   });
 
   describe("findByManagingCodeCapitalProjectId", () => {

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -39,6 +39,7 @@ export class CapitalProjectService {
     agencyBudget = null,
     commitmentsTotalMin = null,
     commitmentsTotalMax = null,
+    isMapped = null,
   }: {
     limit?: number;
     offset?: number;
@@ -48,6 +49,7 @@ export class CapitalProjectService {
     agencyBudget?: string | null;
     commitmentsTotalMin?: string | null;
     commitmentsTotalMax?: string | null;
+    isMapped?: boolean | null;
   }) {
     const min = commitmentsTotalMin
       ? parseFloat(commitmentsTotalMin.replaceAll(",", ""))
@@ -55,6 +57,14 @@ export class CapitalProjectService {
     const max = commitmentsTotalMax
       ? parseFloat(commitmentsTotalMax.replaceAll(",", ""))
       : null;
+
+    if (
+      (cityCouncilDistrictId !== null ||
+        communityDistrictCombinedId !== null) &&
+      isMapped !== null
+    ) {
+      throw new InvalidRequestParameterException();
+    }
 
     if (min !== null && max !== null && min > max) {
       throw new InvalidRequestParameterException();
@@ -104,6 +114,7 @@ export class CapitalProjectService {
       agencyBudget,
       commitmentsTotalMin: min,
       commitmentsTotalMax: max,
+      isMapped,
       limit,
       offset,
     });
@@ -116,6 +127,7 @@ export class CapitalProjectService {
       agencyBudget,
       commitmentsTotalMin: min,
       commitmentsTotalMax: max,
+      isMapped,
     });
 
     const [capitalProjects, totalProjects] = await Promise.all([

--- a/src/gen/types/FindCapitalProjects.ts
+++ b/src/gen/types/FindCapitalProjects.ts
@@ -33,6 +33,11 @@ export type FindCapitalProjectsQueryParams = {
    */
   commitmentsTotalMax?: string;
   /**
+   * @description Used to filter whether a capital project has associated geographic coordinates.
+   * @type boolean | undefined
+   */
+  isMapped?: boolean;
+  /**
    * @description The maximum number of results to be returned in each response. The default value is 20. It must be between 1 and 100, inclusive.
    * @type integer | undefined
    */

--- a/src/gen/zod/findCapitalProjectsSchema.ts
+++ b/src/gen/zod/findCapitalProjectsSchema.ts
@@ -42,6 +42,12 @@ export const findCapitalProjectsQueryParamsSchema = z
         "Maximum sum of total capital commitments to a given capital project, represented by USD amount, with cents and thousands separators both optional.",
       )
       .optional(),
+    isMapped: z
+      .boolean()
+      .describe(
+        "Used to filter whether a capital project has associated geographic coordinates.",
+      )
+      .optional(),
     limit: z.coerce
       .number()
       .int()

--- a/src/pipes/zod-transform-pipe.spec.ts
+++ b/src/pipes/zod-transform-pipe.spec.ts
@@ -8,6 +8,7 @@ describe("zod transform pipe", () => {
     textual: z.coerce.string(),
     numericArray: z.array(z.coerce.number()),
     textualArray: z.array(z.coerce.string()),
+    boolean: z.boolean(), // boolean coercion relies on undesired JS "Boolean" function
   });
 
   const strictSchema = z.object({
@@ -15,6 +16,7 @@ describe("zod transform pipe", () => {
     textual: z.string(),
     numericArray: z.array(z.number()),
     textualArray: z.array(z.string()),
+    boolean: z.boolean(),
   });
 
   it("should parse properly formatted parameters defined in the schema", () => {
@@ -23,6 +25,7 @@ describe("zod transform pipe", () => {
       textual: "text",
       numericArray: "1",
       textualArray: "foo",
+      boolean: "true",
     };
     expect(() => strictSchema.parse(params)).toThrow();
 
@@ -39,6 +42,7 @@ describe("zod transform pipe", () => {
       textual: "text",
       numericArray: ["1", "2"],
       textualArray: ["foo", "bar"],
+      boolean: "true",
     };
     expect(() => strictSchema.parse(params)).toThrow();
 
@@ -55,6 +59,7 @@ describe("zod transform pipe", () => {
       textual: "text",
       numericArray: "1",
       textualArray: "foo",
+      boolean: "true",
     };
 
     expect(() => strictSchema.parse(params)).toThrow();
@@ -70,6 +75,23 @@ describe("zod transform pipe", () => {
       textual: "text",
       numericArray: "1",
       textualArray: "foo",
+      boolean: "true",
+    };
+
+    expect(() => strictSchema.parse(params)).toThrow();
+
+    expect(() => new ZodTransformPipe(testSchema).transform(params)).toThrow(
+      InvalidRequestParameterException,
+    );
+  });
+
+  it("should error when the boolean is not a valid", () => {
+    const params = {
+      numeric: "42",
+      textual: "text",
+      numericArray: "1",
+      textualArray: "foo",
+      boolean: "f",
     };
 
     expect(() => strictSchema.parse(params)).toThrow();

--- a/src/pipes/zod-transform-pipe.ts
+++ b/src/pipes/zod-transform-pipe.ts
@@ -1,6 +1,6 @@
 import { PipeTransform } from "@nestjs/common";
 import { InvalidRequestParameterException } from "src/exception";
-import { ZodRawShape, ZodObject, ZodOptional, ZodArray } from "zod";
+import { ZodRawShape, ZodObject, ZodOptional, ZodArray, ZodBoolean } from "zod";
 export class ZodTransformPipe<T extends ZodRawShape> implements PipeTransform {
   constructor(private schema: ZodObject<T> | ZodOptional<ZodObject<T>>) {}
 
@@ -14,18 +14,31 @@ export class ZodTransformPipe<T extends ZodRawShape> implements PipeTransform {
 
     const decodedParams: Record<
       string,
-      string | number | Array<string> | Array<number>
+      boolean | string | number | Array<string> | Array<number>
     > = {};
 
     Object.entries(params).forEach(([param, value]) => {
       const schema = schemaProperties[param];
       const property = schema instanceof ZodOptional ? schema.unwrap() : schema;
 
-      decodedParams[param] = !(property instanceof ZodArray)
-        ? value
-        : Array.isArray(value)
-          ? value
-          : value.split(",");
+      if (property instanceof ZodArray) {
+        decodedParams[param] = Array.isArray(value) ? value : value.split(",");
+        return;
+      }
+
+      if (property instanceof ZodBoolean) {
+        if (value === "true") {
+          decodedParams[param] = true;
+          return;
+        }
+        if (value === "false") {
+          decodedParams[param] = false;
+          return;
+        }
+        throw new InvalidRequestParameterException();
+      }
+
+      decodedParams[param] = value;
     });
 
     try {

--- a/test/capital-project/capital-project.repository.mock.ts
+++ b/test/capital-project/capital-project.repository.mock.ts
@@ -61,6 +61,8 @@ export class CapitalProjectRepositoryMock {
         communityDistrictId: string;
         agencyBudget: string;
         commitmentsTotal: number;
+        liFtMPoly: string | null;
+        liFtMPnt: string | null;
       },
       FindManyRepo,
     ]
@@ -79,6 +81,8 @@ export class CapitalProjectRepositoryMock {
           communityDistrictId: communityDistrictIdMocks[0].id,
           agencyBudget: agencyBudgetMocks[0].code,
           commitmentsTotal: 100,
+          liFtMPnt: "EXISTS",
+          liFtMPoly: null,
         },
         this.capitalProjectGroups[0],
       ],
@@ -90,6 +94,8 @@ export class CapitalProjectRepositoryMock {
           communityDistrictId: communityDistrictIdMocks[1].id,
           agencyBudget: agencyBudgetMocks[1].code,
           commitmentsTotal: 200,
+          liFtMPnt: null,
+          liFtMPoly: "EXISTS",
         },
         this.capitalProjectGroups[1],
       ],
@@ -101,6 +107,8 @@ export class CapitalProjectRepositoryMock {
           communityDistrictId: communityDistrictIdMocks[1].id,
           agencyBudget: agencyBudgetMocks[1].code,
           commitmentsTotal: 300,
+          liFtMPnt: null,
+          liFtMPoly: null,
         },
         this.capitalProjectGroups[2],
       ],
@@ -115,6 +123,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget,
     commitmentsTotalMin,
     commitmentsTotalMax,
+    isMapped,
   }: {
     managingAgency: string | null;
     cityCouncilDistrictId: string | null;
@@ -123,6 +132,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
+    isMapped: boolean | null;
   }) {
     return this.capitalProjectsCriteria.reduce(
       (acc: FindManyRepo, [criteria, capitalProjects]) => {
@@ -159,6 +169,14 @@ export class CapitalProjectRepositoryMock {
           criteria.commitmentsTotal >= commitmentsTotalMax
         )
           return acc;
+        if (
+          (isMapped === true &&
+            (criteria.liFtMPoly !== null || criteria.liFtMPnt !== null)) ||
+          (isMapped === false &&
+            criteria.liFtMPoly === null &&
+            criteria.liFtMPnt === null)
+        )
+          return acc;
         return acc.concat(capitalProjects);
       },
       [],
@@ -173,6 +191,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget,
     commitmentsTotalMin,
     commitmentsTotalMax,
+    isMapped,
     limit,
     offset,
   }: {
@@ -183,6 +202,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
+    isMapped: boolean | null;
     limit: number;
     offset: number;
   }): Promise<FindManyRepo> {
@@ -194,6 +214,7 @@ export class CapitalProjectRepositoryMock {
       agencyBudget,
       commitmentsTotalMin,
       commitmentsTotalMax,
+      isMapped,
     });
     return results.slice(offset, limit + offset);
   }
@@ -206,6 +227,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget,
     commitmentsTotalMin,
     commitmentsTotalMax,
+    isMapped,
   }: {
     managingAgency: string | null;
     cityCouncilDistrictId: string | null;
@@ -214,6 +236,7 @@ export class CapitalProjectRepositoryMock {
     agencyBudget: string | null;
     commitmentsTotalMin: number | null;
     commitmentsTotalMax: number | null;
+    isMapped: boolean | null;
   }): Promise<FindCountRepo> {
     const results = await this.filterCapitalProjects({
       managingAgency,
@@ -223,6 +246,7 @@ export class CapitalProjectRepositoryMock {
       agencyBudget,
       commitmentsTotalMin,
       commitmentsTotalMax,
+      isMapped,
     });
     return results.length;
   }


### PR DESCRIPTION
## Description

We do not necessarily want projects without a geometry in the list of capital projects. To account for this, we will add an `isMapped` filter.

## Acceptance criteria
- [x] The `capital-projects` endpoint has an `isMapped` filter
- [x] The `isMapped` filter is documented in the openAPI spec
- [x] The `isMapped` filter accepts a boolean value
- [x] The `isMapped` filter is optional
   - When not provided, both mapped and unmapped projects should be return (a test case should assert this)
   - When a `true` value is provided, only projects with non-null geometries are returned (a test case should assert this)
   - When a `false` value is provided, only projects with null geometries are returned (a test case should assert this)
   - When a non-boolean value is provided, a `400 invalid request` parameter should be thrown (a test case should assert this)
- [x] The `isMapped` filter is mutually exclusive with other geographic filters
   - When a `city-council-district` is provided along with an `isMapped` value, return a `400 invalid request` (a test case should assert this)
   - When a `community-district` is provided along with an `isMapped` value, return a `400 invalid request`  (a test case should assert this)

Closes #461 