### PR TITLE
Update invalid request parameter exemption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@nestjs/cli": "^11.0.7",
         "@nestjs/schematics": "^11.0.5",
         "@nestjs/testing": "^11.1.0",
-        "@redocly/cli": "^1.34.2",
+        "@redocly/cli": "^1.34.5",
         "@types/express": "^4.17.17",
         "@types/geojson": "^7946.0.16",
         "@types/jest": "^29.5.14",
@@ -4958,9 +4958,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "1.34.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.2.tgz",
-      "integrity": "sha512-XnKG7yrr0GUZ7MyqHk9hRt//HGUSnLDwwEXI8HDQdyDFp+YFbddqcQPOWc/sDeDBTEiBXqwPOb3/VKA+8NtSMw==",
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.5.tgz",
+      "integrity": "sha512-5IEwxs7SGP5KEXjBKLU8Ffdz9by/KqNSeBk6YUVQaGxMXK//uYlTJIPntgUXbo1KAGG2d2q2XF8y4iFz6qNeiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4970,14 +4970,14 @@
         "@opentelemetry/sdk-trace-node": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@redocly/config": "^0.22.0",
-        "@redocly/openapi-core": "1.34.2",
-        "@redocly/respect-core": "1.34.2",
+        "@redocly/openapi-core": "1.34.5",
+        "@redocly/respect-core": "1.34.5",
         "abort-controller": "^3.0.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
         "core-js": "^3.32.1",
-        "dotenv": "^16.4.7",
-        "form-data": "^4.0.0",
+        "dotenv": "16.4.7",
+        "form-data": "^4.0.4",
         "get-port-please": "^3.0.1",
         "glob": "^7.1.6",
         "handlebars": "^4.7.6",
@@ -4985,7 +4985,7 @@
         "pluralize": "^8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.2.0 || ^19.0.0",
-        "redoc": "2.4.0",
+        "redoc": "2.5.0",
         "semver": "^7.5.2",
         "simple-websocket": "^9.0.0",
         "styled-components": "^6.0.7",
@@ -5009,6 +5009,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@redocly/cli/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@redocly/cli/node_modules/glob": {
@@ -5054,9 +5067,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.2.tgz",
-      "integrity": "sha512-glfkQFJizLdq2fBkNvc2FJW0sxDb5exd0wIXhFk+WHaFLMREBC3CxRo2Zq7uJIdfV9U3YTceMbXJklpDfmmwFQ==",
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.5.tgz",
+      "integrity": "sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5076,21 +5089,21 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "1.34.2",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.2.tgz",
-      "integrity": "sha512-X6VR9bbHXrI01Wh5t6TIHxFCVHcP4Iy42micKLIk/Cg6EmHVbaSDGOD6mxChXtEIrwnY+bqyUbjlXr9+YM7B9A==",
+      "version": "1.34.5",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.5.tgz",
+      "integrity": "sha512-GheC/g/QFztPe9UA9LamooSplQuy9pe0Yr8XGTqkz0ahivLDl7svoy/LSQNn1QH3XGtLKwFYMfTwFR2TAYyh5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@redocly/ajv": "8.11.2",
-        "@redocly/openapi-core": "1.34.2",
+        "@redocly/openapi-core": "1.34.5",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",
         "concat-stream": "^2.0.0",
         "cookie": "^0.7.2",
-        "dotenv": "16.4.5",
-        "form-data": "4.0.0",
+        "dotenv": "16.4.7",
+        "form-data": "^4.0.4",
         "jest-diff": "^29.3.1",
         "jest-matcher-utils": "^29.3.1",
         "js-yaml": "4.1.0",
@@ -5126,9 +5139,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/respect-core/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5136,21 +5149,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@redocly/respect-core/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -7559,9 +7557,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7929,9 +7927,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -8274,6 +8272,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9047,23 +9061,19 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9394,14 +9404,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -9800,6 +9812,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -12498,9 +12526,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.13.6",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.6.tgz",
-      "integrity": "sha512-r19KNV0uBN4b+ER8Z0gA4y+MzDYIQ2SvOmn3fUrqPnWXdQfakd9yfbPBDBF/p5I+bd3N5Rk1fHONIvMay+bJGA==",
+      "version": "6.13.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
+      "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -12627,9 +12655,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -13022,16 +13050,16 @@
       }
     },
     "node_modules/open": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.1.1.tgz",
-      "integrity": "sha512-zy1wx4+P3PfhXSEPJNtZmJXfhkkIaxU1VauWIrDZw1O7uJRDRJtKr9n3Ic4NgbA16KyOxOXO2ng9gYwCdXuSXA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -14222,9 +14250,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -14232,16 +14260,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-is": {
@@ -14306,16 +14334,16 @@
       }
     },
     "node_modules/redoc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.4.0.tgz",
-      "integrity": "sha512-rFlfzFVWS9XJ6aYAs/bHnLhHP5FQEhwAHDBVgwb9L2FqDQ8Hu8rQ1G84iwaWXxZfPP9UWn7JdWkxI6MXr2ZDjw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.5.0.tgz",
+      "integrity": "sha512-NpYsOZ1PD9qFdjbLVBZJWptqE+4Y6TkUuvEOqPUmoH7AKOmPcE+hYjotLxQNTqVoWL4z0T2uxILmcc8JGDci+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@redocly/openapi-core": "^1.4.0",
         "classnames": "^2.3.2",
         "decko": "^1.2.0",
-        "dompurify": "^3.0.6",
+        "dompurify": "^3.2.4",
         "eventemitter3": "^5.0.1",
         "json-pointer": "^0.6.2",
         "lunr": "^2.3.9",
@@ -14752,9 +14780,9 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "dev": true,
       "license": "MIT"
     },
@@ -15442,10 +15470,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/strtok3": {
@@ -15466,9 +15500,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz",
-      "integrity": "sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
+      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16335,9 +16369,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16446,9 +16480,9 @@
       "license": "BSD"
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -16841,6 +16875,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@nestjs/common": "^11.1.0",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.0",
-        "@nestjs/platform-express": "^11.1.3",
+        "@nestjs/platform-express": "^11.1.5",
         "@nestjs/serve-static": "^5.0.3",
         "cache-manager": "^6.4.2",
         "cacheable": "^1.9.0",
@@ -4123,14 +4123,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.3.tgz",
-      "integrity": "sha512-hEDNMlaPiBO72fxxX/CuRQL3MEhKRc/sIYGVoXjrnw6hTxZdezvvM6A95UaLsYknfmcZZa/CdG1SMBZOu9agHQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
+      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "path-to-regexp": "8.2.0",
         "tslib": "2.8.1"
       },
@@ -12595,9 +12595,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,40 +216,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -304,24 +270,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/is-interactive": {
@@ -386,22 +334,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
@@ -4225,24 +4157,6 @@
         }
       }
     },
-    "node_modules/@nestjs/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nestjs/schematics/node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -4305,22 +4219,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nestjs/common": "^11.1.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.0",
-    "@nestjs/platform-express": "^11.1.3",
+    "@nestjs/platform-express": "^11.1.5",
     "@nestjs/serve-static": "^5.0.3",
     "cache-manager": "^6.4.2",
     "cacheable": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@nestjs/cli": "^11.0.7",
     "@nestjs/schematics": "^11.0.5",
     "@nestjs/testing": "^11.1.0",
-    "@redocly/cli": "^1.34.2",
+    "@redocly/cli": "^1.34.5",
     "@types/express": "^4.17.17",
     "@types/geojson": "^7946.0.16",
     "@types/jest": "^29.5.14",

--- a/src/capital-project/capital-project.service.ts
+++ b/src/capital-project/capital-project.service.ts
@@ -63,11 +63,15 @@ export class CapitalProjectService {
         communityDistrictCombinedId !== null) &&
       isMapped !== null
     ) {
-      throw new InvalidRequestParameterException();
+      throw new InvalidRequestParameterException(
+        "cannot have isMapped filter in conjunction with other geographic filter",
+      );
     }
 
     if (min !== null && max !== null && min > max) {
-      throw new InvalidRequestParameterException();
+      throw new InvalidRequestParameterException(
+        "min amount should be less than max amount",
+      );
     }
 
     const checklist: Array<Promise<unknown | undefined>> = [];
@@ -104,7 +108,9 @@ export class CapitalProjectService {
     const checkedList = await Promise.all(checklist);
 
     if (checkedList.some((result) => result === false))
-      throw new InvalidRequestParameterException();
+      throw new InvalidRequestParameterException(
+        "could not check one or more of the parameters",
+      );
 
     const capitalProjectsPromise = this.capitalProjectRepository.findMany({
       cityCouncilDistrictId,

--- a/src/exception/invalid-request-parameter.ts
+++ b/src/exception/invalid-request-parameter.ts
@@ -1,6 +1,6 @@
 export class InvalidRequestParameterException extends Error {
-  constructor() {
-    super("Invalid data type or format for request parameter");
+  constructor(message: string) {
+    super(`Invalid data type or format for request parameter: ${message}`);
     this.name = "InvalidRequestParameterException";
   }
 }

--- a/src/exception/invalid-request-parameter.ts
+++ b/src/exception/invalid-request-parameter.ts
@@ -1,6 +1,6 @@
 export class InvalidRequestParameterException extends Error {
   constructor(message: string) {
-    super(`Invalid data type or format for request parameter: ${message}`);
+    super(`Invalid request parameter: ${message}`);
     this.name = "InvalidRequestParameterException";
   }
 }

--- a/src/pipes/zod-transform-pipe.ts
+++ b/src/pipes/zod-transform-pipe.ts
@@ -35,7 +35,7 @@ export class ZodTransformPipe<T extends ZodRawShape> implements PipeTransform {
           decodedParams[param] = false;
           return;
         }
-        throw new InvalidRequestParameterException();
+        throw new InvalidRequestParameterException("invalid value for boolean schema property");
       }
 
       decodedParams[param] = value;
@@ -46,7 +46,7 @@ export class ZodTransformPipe<T extends ZodRawShape> implements PipeTransform {
       if (parsedParams === undefined) throw new Error();
       return parsedParams;
     } catch (error) {
-      throw new InvalidRequestParameterException();
+      throw new InvalidRequestParameterException("no params");
     }
   }
 }

--- a/test/borough/borough.e2e-spec.ts
+++ b/test/borough/borough.e2e-spec.ts
@@ -166,7 +166,7 @@ describe("Borough e2e", () => {
         .get(`/boroughs/1/community-districts/${longId}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -177,7 +177,7 @@ describe("Borough e2e", () => {
         .get(`/boroughs/1/community-districts/${letterId}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -270,7 +270,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -283,7 +283,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -399,7 +399,7 @@ describe("Borough e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
@@ -418,7 +418,7 @@ describe("Borough e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
@@ -435,7 +435,7 @@ describe("Borough e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);

--- a/test/borough/borough.e2e-spec.ts
+++ b/test/borough/borough.e2e-spec.ts
@@ -12,10 +12,7 @@ import {
   findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictsByBoroughIdQueryResponseSchema,
 } from "src/gen";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { AgencyBudgetRepositoryMock } from "test/agency-budget/agency-budget.repository.mock";
@@ -143,7 +140,7 @@ describe("Borough e2e", () => {
     });
   });
 
-  describe("findCityCouncilDistrictGeoJsonByCityCouncilDistrictId", () => {
+  describe("findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdMocks", () => {
     it("should 200 and return documented schema when finding by valid id", async () => {
       const mock =
         boroughRepositoryMock
@@ -165,9 +162,7 @@ describe("Borough e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/boroughs/1/community-districts/${longId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -176,9 +171,7 @@ describe("Borough e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/boroughs/1/community-districts/${letterId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -269,9 +262,7 @@ describe("Borough e2e", () => {
           `/boroughs/${missingId}/community-districts/${communityDistrict.id}/capital-projects`,
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -282,9 +273,8 @@ describe("Borough e2e", () => {
           `/boroughs/${communityDistrict.boroughId}/community-districts/${missingId}/capital-projects`,
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
+
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -398,9 +388,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/boroughId: Invalid/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -417,9 +405,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -434,10 +420,9 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
-
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -12,10 +12,7 @@ import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { AgencyBudgetRepositoryMock } from "test/agency-budget/agency-budget.repository.mock";
 import * as request from "supertest";
 import { HttpName } from "src/filter";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import {
   findCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponseSchema,
   findCapitalProjectByManagingCodeCapitalProjectIdQueryResponseSchema,
@@ -122,9 +119,7 @@ describe("Capital Projects", () => {
         `/capital-projects?agencyBudget=${agencyBudgetCode}`,
       );
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -132,9 +127,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -142,9 +135,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=101",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be less/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -152,9 +143,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=0",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be greater/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -162,9 +151,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?offset=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -192,9 +179,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?cityCouncilDistrictId=${id}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -222,9 +207,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?communityDistrictId=${id}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -253,9 +236,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?managingAgency=${managingAgency}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -283,9 +264,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/commitmentsTotalMin: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -313,9 +292,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMax=${commitmentsTotalMax}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/commitmentsTotalMax: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -325,9 +302,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}&commitmentsTotalMax=${commitmentsTotalMax}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/min amount should be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -407,9 +382,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?isMapped=123`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/invalid value for boolean/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -417,8 +390,8 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?cityCouncilDistrictId=50&isMapped=true`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /cannot have isMapped filter in conjunction/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -427,8 +400,8 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?communityDistrictId=101&isMapped=true`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /cannot have isMapped filter in conjunction/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -534,9 +507,6 @@ describe("Capital Projects", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -609,9 +579,9 @@ describe("Capital Projects", () => {
         .get(`/capital-projects/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -123,7 +123,7 @@ describe("Capital Projects", () => {
       );
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -133,7 +133,7 @@ describe("Capital Projects", () => {
         "/capital-projects?limit=b4d",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -143,7 +143,7 @@ describe("Capital Projects", () => {
         "/capital-projects?limit=101",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -153,7 +153,7 @@ describe("Capital Projects", () => {
         "/capital-projects?limit=0",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -163,7 +163,7 @@ describe("Capital Projects", () => {
         "/capital-projects?offset=b4d",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -193,7 +193,7 @@ describe("Capital Projects", () => {
         `/capital-projects?cityCouncilDistrictId=${id}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -223,7 +223,7 @@ describe("Capital Projects", () => {
         `/capital-projects?communityDistrictId=${id}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -254,7 +254,7 @@ describe("Capital Projects", () => {
         `/capital-projects?managingAgency=${managingAgency}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -284,7 +284,7 @@ describe("Capital Projects", () => {
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -314,7 +314,7 @@ describe("Capital Projects", () => {
         `/capital-projects?commitmentsTotalMax=${commitmentsTotalMax}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -326,7 +326,7 @@ describe("Capital Projects", () => {
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}&commitmentsTotalMax=${commitmentsTotalMax}`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -408,7 +408,7 @@ describe("Capital Projects", () => {
         `/capital-projects?isMapped=123`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -418,7 +418,7 @@ describe("Capital Projects", () => {
         `/capital-projects?cityCouncilDistrictId=50&isMapped=true`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -428,7 +428,7 @@ describe("Capital Projects", () => {
         `/capital-projects?communityDistrictId=101&isMapped=true`,
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -535,7 +535,7 @@ describe("Capital Projects", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -610,7 +610,7 @@ describe("Capital Projects", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);

--- a/test/city-council-district/city-council-district.e2e-spec.ts
+++ b/test/city-council-district/city-council-district.e2e-spec.ts
@@ -110,7 +110,7 @@ describe("City Council District e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
@@ -157,7 +157,7 @@ describe("City Council District e2e", () => {
         .get(`/city-council-districts/${longId}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -168,7 +168,7 @@ describe("City Council District e2e", () => {
         .get(`/city-council-districts/${letterId}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -226,7 +226,7 @@ describe("City Council District e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
@@ -244,7 +244,7 @@ describe("City Council District e2e", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
@@ -360,7 +360,7 @@ describe("City Council District e2e", () => {
         .get(`/city-council-districts/${missingId}/capital-projects`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/city-council-district/city-council-district.e2e-spec.ts
+++ b/test/city-council-district/city-council-district.e2e-spec.ts
@@ -1,10 +1,7 @@
 import * as request from "supertest";
 import { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CityCouncilDistrictRepositoryMock } from "./city-council-district.repository.mock";
@@ -109,9 +106,9 @@ describe("City Council District e2e", () => {
         .get(`/city-council-districts/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -156,9 +153,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${longId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -167,9 +162,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${letterId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -225,10 +218,7 @@ describe("City Council District e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
-
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -243,9 +233,9 @@ describe("City Council District e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -323,6 +313,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${invalidId}/capital-projects`)
         .expect(400);
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -330,6 +321,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=b4d`)
         .expect(400);
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -337,13 +329,15 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=101`)
         .expect(400);
-
+      expect(response.body.message).toMatch(/limit: Number must be less/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
+
     it("should 400 and when finding by an 'too-low' limit", async () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=0`)
         .expect(400);
+      expect(response.body.message).toMatch(/limit: Number must be greater/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -351,6 +345,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?offset=b4d`)
         .expect(400);
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -359,9 +354,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${missingId}/capital-projects`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
   });

--- a/test/community-district/community-district.e2e-spec.ts
+++ b/test/community-district/community-district.e2e-spec.ts
@@ -51,7 +51,7 @@ describe("Community Districts", () => {
         .expect(400);
 
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);

--- a/test/community-district/community-district.e2e-spec.ts
+++ b/test/community-district/community-district.e2e-spec.ts
@@ -5,10 +5,7 @@ import { CommunityDistrictRepository } from "src/community-district/community-di
 import { CommunityDistrictRepositoryMock } from "./community-district.repository.mock";
 import * as request from "supertest";
 import { HttpName } from "src/filter";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 
 describe("Community Districts", () => {
   let app: INestApplication;
@@ -50,9 +47,9 @@ describe("Community Districts", () => {
         .get(`/community-districts/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/tax-lot/tax-lot.e2e-spec.ts
+++ b/test/tax-lot/tax-lot.e2e-spec.ts
@@ -92,7 +92,7 @@ describe("TaxLots", () => {
         "/tax-lots?limit=[4]",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -102,7 +102,7 @@ describe("TaxLots", () => {
         "/tax-lots?limit=b4d",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -112,7 +112,7 @@ describe("TaxLots", () => {
         "/tax-lots?limit=101",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -122,7 +122,7 @@ describe("TaxLots", () => {
         "/tax-lots?limit=0",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -132,7 +132,7 @@ describe("TaxLots", () => {
         "/tax-lots?offset=b4d",
       );
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -142,7 +142,7 @@ describe("TaxLots", () => {
         .get("/tax-lots?geometry=linestring&lons=0,1&lats=0,1")
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -152,7 +152,7 @@ describe("TaxLots", () => {
         .get("/tax-lots?geometry=LineString&lons=0,1,2,3,4,5&lats=0,1,2,3,4,5")
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -162,7 +162,7 @@ describe("TaxLots", () => {
         .get("/tax-lots?geometry=LineString&lons=DROPTables&lats=DROPDatabase")
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -174,7 +174,7 @@ describe("TaxLots", () => {
         )
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -223,7 +223,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${shortBbl}`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -234,7 +234,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${letterBbl}`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -280,7 +280,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${shortBbl}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -291,7 +291,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${letterBbl}/geojson`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -339,7 +339,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${shortBbl}/zoning-districts`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -350,7 +350,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${letterBbl}/zoning-districts`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -400,7 +400,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${shortBbl}/zoning-districts/classes`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -411,7 +411,7 @@ describe("TaxLots", () => {
         .get(`/tax-lots/${letterBbl}/zoning-districts/classes`)
         .expect(400);
       expect(response.body.message).toBe(
-        new InvalidRequestParameterException().message,
+        new InvalidRequestParameterException("invalid parameters").message,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/tax-lot/tax-lot.e2e-spec.ts
+++ b/test/tax-lot/tax-lot.e2e-spec.ts
@@ -11,10 +11,7 @@ import {
   findTaxLotsQueryResponseSchema,
 } from "src/gen";
 import { TaxLotRepositoryMock } from "./tax-lot.repository.mock";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { NestExpressApplication } from "@nestjs/platform-express";
 
@@ -91,9 +88,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=[4]",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -101,9 +96,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -111,9 +104,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=101",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -121,9 +112,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=0",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -131,9 +120,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?offset=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -141,9 +128,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=linestring&lons=0,1&lats=0,1")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/geometry: Invalid enum value./);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -151,8 +136,11 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=LineString&lons=0,1,2,3,4,5&lats=0,1,2,3,4,5")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /lons: Array must contain at most 5/,
+      );
+      expect(response.body.message).toMatch(
+        /lats: Array must contain at most 5/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -161,9 +149,8 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=LineString&lons=DROPTables&lats=DROPDatabase")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/lons: Expected number/);
+      expect(response.body.message).toMatch(/lats: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -173,9 +160,7 @@ describe("TaxLots", () => {
           "/tax-lots?geometry=LineString&lons=0,1,2,3,4&lats=0,1,2,3,4&buffer=b4d",
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/buffer: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -222,9 +207,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -233,9 +216,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -279,9 +260,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -290,9 +269,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -338,9 +315,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/zoning-districts`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -349,11 +324,10 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/zoning-districts`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
+
     it("should 404 when finding by missing bbl", async () => {
       const missingBbl = "0123456789";
       const response = await request(app.getHttpServer())
@@ -399,9 +373,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/zoning-districts/classes`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -410,9 +382,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/zoning-districts/classes`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/zoning-district-class/zoning-district-class.e2e-spec.ts
+++ b/test/zoning-district-class/zoning-district-class.e2e-spec.ts
@@ -4,10 +4,7 @@ import { Test } from "@nestjs/testing";
 import { ZoningDistrictClassModule } from "src/zoning-district-class/zoning-district-class.module";
 import { ZoningDistrictClassRepositoryMock } from "./zoning-district-class.repository.mock";
 import { ZoningDistrictClassRepository } from "src/zoning-district-class/zoning-district-class.repository";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import {
   findZoningDistrictClassByZoningDistrictClassIdQueryResponseSchema,
@@ -94,17 +91,12 @@ describe("Zoning District Classes e2e", () => {
     });
 
     it("should 400 and throw 'Bad Request' error with an invalid id", async () => {
-      const invalidRequestParameterException =
-        new InvalidRequestParameterException("invalid paramters");
-
       const invalidId = "CC";
       const response = await request(app.getHttpServer())
         .get(`/zoning-district-classes/${invalidId}`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        invalidRequestParameterException.message,
-      );
+      expect(response.body.message).toMatch(/id: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/zoning-district-class/zoning-district-class.e2e-spec.ts
+++ b/test/zoning-district-class/zoning-district-class.e2e-spec.ts
@@ -95,7 +95,7 @@ describe("Zoning District Classes e2e", () => {
 
     it("should 400 and throw 'Bad Request' error with an invalid id", async () => {
       const invalidRequestParameterException =
-        new InvalidRequestParameterException();
+        new InvalidRequestParameterException("invalid paramters");
 
       const invalidId = "CC";
       const response = await request(app.getHttpServer())


### PR DESCRIPTION
Add zod error details to messages of invalid request parameters

**Note** In an earlier version of this code, there was a check for generic errors. I had to get rid of it because `ZodError` extends `Error` and therefore is technically also an `instanceof Error`