### PR TITLE
Update invalid request parameter exemption

### DIFF
--- a/src/exception/invalid-request-parameter.ts
+++ b/src/exception/invalid-request-parameter.ts
@@ -1,6 +1,6 @@
 export class InvalidRequestParameterException extends Error {
   constructor(message: string) {
-    super(`Invalid data type or format for request parameter: ${message}`);
+    super(`Invalid request parameter: ${message}`);
     this.name = "InvalidRequestParameterException";
   }
 }

--- a/test/borough/borough.e2e-spec.ts
+++ b/test/borough/borough.e2e-spec.ts
@@ -12,10 +12,7 @@ import {
   findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdQueryResponseSchema,
   findCommunityDistrictsByBoroughIdQueryResponseSchema,
 } from "src/gen";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { AgencyBudgetRepositoryMock } from "test/agency-budget/agency-budget.repository.mock";
@@ -143,7 +140,7 @@ describe("Borough e2e", () => {
     });
   });
 
-  describe("findCityCouncilDistrictGeoJsonByCityCouncilDistrictId", () => {
+  describe("findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdMocks", () => {
     it("should 200 and return documented schema when finding by valid id", async () => {
       const mock =
         boroughRepositoryMock
@@ -165,9 +162,7 @@ describe("Borough e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/boroughs/1/community-districts/${longId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -176,9 +171,7 @@ describe("Borough e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/boroughs/1/community-districts/${letterId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -269,9 +262,7 @@ describe("Borough e2e", () => {
           `/boroughs/${missingId}/community-districts/${communityDistrict.id}/capital-projects`,
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -282,9 +273,8 @@ describe("Borough e2e", () => {
           `/boroughs/${communityDistrict.boroughId}/community-districts/${missingId}/capital-projects`,
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
+
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -398,9 +388,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/boroughId: Invalid/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -417,9 +405,7 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -434,10 +420,9 @@ describe("Borough e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
-
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/capital-project/capital-project.e2e-spec.ts
+++ b/test/capital-project/capital-project.e2e-spec.ts
@@ -12,10 +12,7 @@ import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { AgencyBudgetRepositoryMock } from "test/agency-budget/agency-budget.repository.mock";
 import * as request from "supertest";
 import { HttpName } from "src/filter";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import {
   findCapitalCommitmentsByManagingCodeCapitalProjectIdQueryResponseSchema,
   findCapitalProjectByManagingCodeCapitalProjectIdQueryResponseSchema,
@@ -122,9 +119,7 @@ describe("Capital Projects", () => {
         `/capital-projects?agencyBudget=${agencyBudgetCode}`,
       );
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -132,9 +127,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -142,9 +135,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=101",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be less/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -152,9 +143,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?limit=0",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be greater/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -162,9 +151,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         "/capital-projects?offset=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -192,9 +179,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?cityCouncilDistrictId=${id}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -222,9 +207,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?communityDistrictId=${id}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/communityDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -253,9 +236,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?managingAgency=${managingAgency}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -283,9 +264,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/commitmentsTotalMin: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -313,9 +292,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMax=${commitmentsTotalMax}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/commitmentsTotalMax: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -325,9 +302,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?commitmentsTotalMin=${commitmentsTotalMin}&commitmentsTotalMax=${commitmentsTotalMax}`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/min amount should be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -407,9 +382,7 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?isMapped=123`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/invalid value for boolean/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -417,8 +390,8 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?cityCouncilDistrictId=50&isMapped=true`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /cannot have isMapped filter in conjunction/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -427,8 +400,8 @@ describe("Capital Projects", () => {
       const response = await request(app.getHttpServer()).get(
         `/capital-projects?communityDistrictId=101&isMapped=true`,
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /cannot have isMapped filter in conjunction/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -534,9 +507,6 @@ describe("Capital Projects", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -609,9 +579,9 @@ describe("Capital Projects", () => {
         .get(`/capital-projects/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/city-council-district/city-council-district.e2e-spec.ts
+++ b/test/city-council-district/city-council-district.e2e-spec.ts
@@ -1,10 +1,7 @@
 import * as request from "supertest";
 import { INestApplication } from "@nestjs/common";
 import { Test } from "@nestjs/testing";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { CityCouncilDistrictRepository } from "src/city-council-district/city-council-district.repository";
 import { CityCouncilDistrictRepositoryMock } from "./city-council-district.repository.mock";
@@ -109,9 +106,9 @@ describe("City Council District e2e", () => {
         .get(`/city-council-districts/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -156,9 +153,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${longId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -167,9 +162,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${letterId}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -225,10 +218,7 @@ describe("City Council District e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
-
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -243,9 +233,9 @@ describe("City Council District e2e", () => {
         )
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -323,6 +313,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${invalidId}/capital-projects`)
         .expect(400);
+      expect(response.body.message).toMatch(/cityCouncilDistrictId: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -330,6 +321,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=b4d`)
         .expect(400);
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -337,13 +329,15 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=101`)
         .expect(400);
-
+      expect(response.body.message).toMatch(/limit: Number must be less/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
+
     it("should 400 and when finding by an 'too-low' limit", async () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?limit=0`)
         .expect(400);
+      expect(response.body.message).toMatch(/limit: Number must be greater/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -351,6 +345,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${mock.id}/capital-projects?offset=b4d`)
         .expect(400);
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -359,9 +354,7 @@ describe("City Council District e2e", () => {
       const response = await request(app.getHttpServer())
         .get(`/city-council-districts/${missingId}/capital-projects`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/could not check/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
   });

--- a/test/community-district/community-district.e2e-spec.ts
+++ b/test/community-district/community-district.e2e-spec.ts
@@ -5,10 +5,7 @@ import { CommunityDistrictRepository } from "src/community-district/community-di
 import { CommunityDistrictRepositoryMock } from "./community-district.repository.mock";
 import * as request from "supertest";
 import { HttpName } from "src/filter";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 
 describe("Community Districts", () => {
   let app: INestApplication;
@@ -50,9 +47,9 @@ describe("Community Districts", () => {
         .get(`/community-districts/${z}/${x}/${y}.pbf`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/z: Expected number/);
+      expect(response.body.message).toMatch(/x: Expected number/);
+      expect(response.body.message).toMatch(/y: Expected number/);
 
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });

--- a/test/tax-lot/tax-lot.e2e-spec.ts
+++ b/test/tax-lot/tax-lot.e2e-spec.ts
@@ -11,10 +11,7 @@ import {
   findTaxLotsQueryResponseSchema,
 } from "src/gen";
 import { TaxLotRepositoryMock } from "./tax-lot.repository.mock";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import { NestExpressApplication } from "@nestjs/platform-express";
 
@@ -91,9 +88,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=[4]",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -101,9 +96,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -111,9 +104,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=101",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -121,9 +112,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?limit=0",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/limit: Number must be/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -131,9 +120,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer()).get(
         "/tax-lots?offset=b4d",
       );
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/offset: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -141,9 +128,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=linestring&lons=0,1&lats=0,1")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/geometry: Invalid enum value./);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -151,8 +136,11 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=LineString&lons=0,1,2,3,4,5&lats=0,1,2,3,4,5")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
+      expect(response.body.message).toMatch(
+        /lons: Array must contain at most 5/,
+      );
+      expect(response.body.message).toMatch(
+        /lats: Array must contain at most 5/,
       );
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
@@ -161,9 +149,8 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get("/tax-lots?geometry=LineString&lons=DROPTables&lats=DROPDatabase")
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/lons: Expected number/);
+      expect(response.body.message).toMatch(/lats: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -173,9 +160,7 @@ describe("TaxLots", () => {
           "/tax-lots?geometry=LineString&lons=0,1,2,3,4&lats=0,1,2,3,4&buffer=b4d",
         )
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/buffer: Expected number/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -222,9 +207,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -233,9 +216,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -279,9 +260,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -290,9 +269,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/geojson`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -338,9 +315,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/zoning-districts`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -349,11 +324,10 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/zoning-districts`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
+
     it("should 404 when finding by missing bbl", async () => {
       const missingBbl = "0123456789";
       const response = await request(app.getHttpServer())
@@ -399,9 +373,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${shortBbl}/zoning-districts/classes`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
@@ -410,9 +382,7 @@ describe("TaxLots", () => {
       const response = await request(app.getHttpServer())
         .get(`/tax-lots/${letterBbl}/zoning-districts/classes`)
         .expect(400);
-      expect(response.body.message).toBe(
-        new InvalidRequestParameterException("invalid parameters").message,
-      );
+      expect(response.body.message).toMatch(/bbl: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/zoning-district-class/zoning-district-class.e2e-spec.ts
+++ b/test/zoning-district-class/zoning-district-class.e2e-spec.ts
@@ -4,10 +4,7 @@ import { Test } from "@nestjs/testing";
 import { ZoningDistrictClassModule } from "src/zoning-district-class/zoning-district-class.module";
 import { ZoningDistrictClassRepositoryMock } from "./zoning-district-class.repository.mock";
 import { ZoningDistrictClassRepository } from "src/zoning-district-class/zoning-district-class.repository";
-import {
-  DataRetrievalException,
-  InvalidRequestParameterException,
-} from "src/exception";
+import { DataRetrievalException } from "src/exception";
 import { HttpName } from "src/filter";
 import {
   findZoningDistrictClassByZoningDistrictClassIdQueryResponseSchema,
@@ -94,17 +91,12 @@ describe("Zoning District Classes e2e", () => {
     });
 
     it("should 400 and throw 'Bad Request' error with an invalid id", async () => {
-      const invalidRequestParameterException =
-        new InvalidRequestParameterException("invalid paramters");
-
       const invalidId = "CC";
       const response = await request(app.getHttpServer())
         .get(`/zoning-district-classes/${invalidId}`)
         .expect(400);
 
-      expect(response.body.message).toBe(
-        invalidRequestParameterException.message,
-      );
+      expect(response.body.message).toMatch(/id: Invalid/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 


### PR DESCRIPTION
Add zod error details to messages of invalid request parameters\

**Note** In an earlier version of this code, there was a check for generic errors. I had to get rid of it because `ZodError` extends `Error` and therefore is technically also an `instanceof Error`