### PR TITLE
487/policy areas single query

### DIFF
--- a/src/community-board-budget-request/community-board-budget-request.controller.ts
+++ b/src/community-board-budget-request/community-board-budget-request.controller.ts
@@ -24,7 +24,7 @@ export class CommunityBoardBudgetRequestController {
   ) {}
 
   @Get("/policy-areas")
-  async findManyCbbrPolicyArea(
+  async findPolicyAreas(
     @Query(
       new ZodTransformPipe(
         findCommunityBoardBudgetRequestPolicyAreasQueryParamsSchema,
@@ -32,8 +32,6 @@ export class CommunityBoardBudgetRequestController {
     )
     queryParams: FindCommunityBoardBudgetRequestPolicyAreasQueryParams,
   ) {
-    return this.communityBoardBudgetRequestService.findManyCbbrPolicyArea(
-      queryParams,
-    );
+    return this.communityBoardBudgetRequestService.findPolicyAreas(queryParams);
   }
 }

--- a/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
@@ -1,10 +1,6 @@
 import { cbbrPolicyAreaEntitySchema } from "src/schema";
 import { z } from "zod";
 
-export const findManyCbbrPolicyAreaRepoSchema = z.array(
-  cbbrPolicyAreaEntitySchema,
-);
+export const findPolicyAreasRepoSchema = z.array(cbbrPolicyAreaEntitySchema);
 
-export type FindManyCbbrPolicyAreaRepo = z.infer<
-  typeof findManyCbbrPolicyAreaRepoSchema
->;
+export type findPolicyAreasRepo = z.infer<typeof findPolicyAreasRepoSchema>;

--- a/src/community-board-budget-request/community-board-budget-request.repository.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.ts
@@ -1,7 +1,7 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { DataRetrievalException } from "src/exception";
-import { FindManyCbbrPolicyAreaRepo } from "./community-board-budget-request.repository.schema";
+import { findPolicyAreasRepo } from "./community-board-budget-request.repository.schema";
 import { cbbrPolicyArea, cbbrOptionCascade } from "src/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { FindCommunityBoardBudgetRequestPolicyAreasQueryParams } from "src/gen";
@@ -15,10 +15,10 @@ export class CommunityBoardBudgetRequestRepository {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
-  async findManyCbbrPolicyArea({
+  async findPolicyAreas({
     cbbrNeedGroupId,
     agencyInitials,
-  }: FindCommunityBoardBudgetRequestPolicyAreasQueryParams): Promise<FindManyCbbrPolicyAreaRepo> {
+  }: FindCommunityBoardBudgetRequestPolicyAreasQueryParams): Promise<findPolicyAreasRepo> {
     try {
       return await this.db
         .selectDistinct({

--- a/src/community-board-budget-request/community-board-budget-request.service.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.ts
@@ -9,13 +9,11 @@ export class CommunityBoardBudgetRequestService {
     private readonly communityBoardBudgetRequestRepository: CommunityBoardBudgetRequestRepository,
   ) {}
 
-  async findManyCbbrPolicyArea(
+  async findPolicyAreas(
     params: FindCommunityBoardBudgetRequestPolicyAreasQueryParams,
   ) {
     const cbbrPolicyAreas =
-      await this.communityBoardBudgetRequestRepository.findManyCbbrPolicyArea(
-        params,
-      );
+      await this.communityBoardBudgetRequestRepository.findPolicyAreas(params);
     return {
       cbbrPolicyAreas,
     };


### PR DESCRIPTION
# Description

`487-policy-areas-endpoint` is coming along well. Below are a few suggestions, divided into two commits.

## Commit One
- Combining the two queries on lines 26 and 40. This helps Postgres see the whole query and optimize the retrieval of the data we want
- Removing the query path on line 23. The `join` of the "combined" query is conditional, meaning it's only performed if necessary. We still perform a `selectDistinct` in the big query. But in the cases where we don't perform the join, the `selectDistinct` is only on the `cbbrPolicyArea` table; the performance impact is negligible.
- Explicitly checking for `undefined`. This proactively guards against bugs caused by `falsy` numbers and strings

## Commit Two
- Changing service and repo names from `findManyCbbrPolicyAreas` to `findPolicyAreas`
  - This is my interpretation of the [naming guidelines](https://github.com/NYCPlanning/ae-wiki/pull/1/files#diff-d8153e52dc7190c6d00cf55f76413c59c8c687959b8714dca426f09d58a83ad1R20), with "Community Board Budget Requests" being the "home domain" 
