### PR TITLE
487/policy area test data

### DIFF
--- a/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
@@ -4,3 +4,9 @@ import { z } from "zod";
 export const findPolicyAreasRepoSchema = z.array(cbbrPolicyAreaEntitySchema);
 
 export type FindPolicyAreasRepo = z.infer<typeof findPolicyAreasRepoSchema>;
+
+export const checkNeedGroupByIdRepoSchema = z.boolean();
+
+export type CheckNeedGroupByIdRepo = z.infer<
+  typeof checkNeedGroupByIdRepoSchema
+>;

--- a/src/community-board-budget-request/community-board-budget-request.repository.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.ts
@@ -1,7 +1,10 @@
 import { Inject } from "@nestjs/common";
 import { DB, DbType } from "src/global/providers/db.provider";
 import { DataRetrievalException } from "src/exception";
-import { FindPolicyAreasRepo } from "./community-board-budget-request.repository.schema";
+import {
+  CheckNeedGroupByIdRepo,
+  FindPolicyAreasRepo,
+} from "./community-board-budget-request.repository.schema";
 import { cbbrPolicyArea, cbbrOptionCascade } from "src/schema";
 import { eq, and, sql } from "drizzle-orm";
 import { FindCommunityBoardBudgetRequestPolicyAreasQueryParams } from "src/gen";
@@ -15,6 +18,36 @@ export class CommunityBoardBudgetRequestRepository {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
+  #checkNeedGroupById = this.db.query.cbbrNeedGroup
+    .findFirst({
+      columns: {
+        id: true,
+      },
+      where: (cbbrNeedGroup, { eq, sql }) =>
+        eq(cbbrNeedGroup.id, sql.placeholder("id")),
+    })
+    .prepare("#checkNeedGroupById");
+
+  async checkNeedGroupById(id: number): Promise<CheckNeedGroupByIdRepo> {
+    const key = JSON.stringify({
+      id,
+      domain: "communityBoardBudgetRequest",
+      function: "checkNeedGroupById",
+    });
+    const cachedValue: CheckNeedGroupByIdRepo | null =
+      await this.cacheManager.get(key);
+    if (cachedValue !== null) return cachedValue;
+    try {
+      const result = await this.#checkNeedGroupById.execute({ id });
+      const value = result !== undefined;
+      this.cacheManager.set(key, value);
+      return value;
+    } catch {
+      throw new DataRetrievalException(
+        "cannot find community board budget request need group by its id",
+      );
+    }
+  }
   async findPolicyAreas({
     cbbrNeedGroupId,
     agencyInitials,

--- a/src/community-board-budget-request/community-board-budget-request.service.spec.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.spec.ts
@@ -5,6 +5,7 @@ import { CommunityBoardBudgetRequestService } from "./community-board-budget-req
 import { CommunityBoardBudgetRequestRepository } from "./community-board-budget-request.repository";
 import { AgencyRepositoryMock } from "test/agency/agency.repository.mock";
 import { AgencyRepository } from "src/agency/agency.repository";
+import { InvalidRequestParameterException } from "src/exception";
 
 describe("Community Board Budget Request service unit", () => {
   let communityBoardBudgetRequestService: CommunityBoardBudgetRequestService;
@@ -50,8 +51,8 @@ describe("Community Board Budget Request service unit", () => {
     });
 
     it("should filter policy areas by cbbrNeedGroupId", async () => {
-      const { needGroupId } =
-        communityBoardBudgetRequestRepositoryMock.cbbrOptionCascade[0];
+      const { id: needGroupId } =
+        communityBoardBudgetRequestRepositoryMock.needGroupMocks[0];
       const policyAreas =
         await communityBoardBudgetRequestService.findPolicyAreas({
           cbbrNeedGroupId: needGroupId,
@@ -59,14 +60,23 @@ describe("Community Board Budget Request service unit", () => {
       expect(policyAreas.cbbrPolicyAreas.length).toBe(1);
     });
 
+    it("should return an InvalidRequestParameter error when an agency with the given initials cannot be found", async () => {
+      const agencyInitials = "FAKE";
+
+      expect(
+        communityBoardBudgetRequestService.findPolicyAreas({
+          agencyInitials,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
     it("should filter policy areas by agencyInitials", async () => {
-      const { agencyInitials } =
-        communityBoardBudgetRequestRepositoryMock.cbbrOptionCascade[0];
+      const { initials: agencyInitials } = agencyRepositoryMock.agencies[0];
       const policyAreas =
         await communityBoardBudgetRequestService.findPolicyAreas({
           agencyInitials,
         });
-      expect(policyAreas.cbbrPolicyAreas.length).toBe(1);
+      expect(policyAreas.cbbrPolicyAreas.length).toBe(4);
     });
   });
 });

--- a/src/community-board-budget-request/community-board-budget-request.service.spec.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.spec.ts
@@ -50,6 +50,16 @@ describe("Community Board Budget Request service unit", () => {
       expect(policyAreas.cbbrPolicyAreas.length).toBe(8);
     });
 
+    it("should return an InvalidRequestParameter error when a need group with the given id cannot be found", async () => {
+      const cbbrNeedGroupId = 0;
+
+      expect(
+        communityBoardBudgetRequestService.findPolicyAreas({
+          cbbrNeedGroupId,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
     it("should filter policy areas by cbbrNeedGroupId", async () => {
       const { id: needGroupId } =
         communityBoardBudgetRequestRepositoryMock.needGroupMocks[0];

--- a/src/community-board-budget-request/community-board-budget-request.service.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.ts
@@ -23,6 +23,17 @@ export class CommunityBoardBudgetRequestService {
         throw new InvalidRequestParameterException("Invalid agency initials");
       }
     }
+    if (cbbrNeedGroupId !== undefined) {
+      const checkNeedGroupId =
+        await this.communityBoardBudgetRequestRepository.checkNeedGroupById(
+          cbbrNeedGroupId,
+        );
+      if (checkNeedGroupId === false)
+        throw new InvalidRequestParameterException(
+          "Need group id does not exist",
+        );
+    }
+
     const cbbrPolicyAreas =
       await this.communityBoardBudgetRequestRepository.findPolicyAreas({
         cbbrNeedGroupId,

--- a/src/community-board-budget-request/community-board-budget-request.service.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.ts
@@ -20,9 +20,12 @@ export class CommunityBoardBudgetRequestService {
       const checkAgencyInitials =
         await this.agencyRepository.checkByInitials(agencyInitials);
       if (checkAgencyInitials === false) {
-        throw new InvalidRequestParameterException("Invalid agency initials");
+        throw new InvalidRequestParameterException(
+          "Agency initials do not exist",
+        );
       }
     }
+
     if (cbbrNeedGroupId !== undefined) {
       const checkNeedGroupId =
         await this.communityBoardBudgetRequestRepository.checkNeedGroupById(

--- a/src/schema/community-board-budget-request.ts
+++ b/src/schema/community-board-budget-request.ts
@@ -22,6 +22,15 @@ export const cbbrNeedGroup = pgTable("cbbr_need_group", {
   description: text("description").notNull(),
 });
 
+export const cbbrNeedGroupEntitySchema = z.object({
+  id: z.number(),
+  description: z.string(),
+});
+
+export type CbbrNeedGroupEntitySchema = z.infer<
+  typeof cbbrNeedGroupEntitySchema
+>;
+
 export const cbbrNeed = pgTable("cbbr_need", {
   id: smallint("id").generatedByDefaultAsIdentity().primaryKey(),
   description: text("description").notNull(),

--- a/test/agency/agency.repository.mock.ts
+++ b/test/agency/agency.repository.mock.ts
@@ -11,9 +11,6 @@ export class AgencyRepositoryMock {
   );
 
   async checkByInitials(managingAgency: string): Promise<CheckByInitialsRepo> {
-    // override so cbbr tests work correctly
-    if (managingAgency === "DOHMH") return true;
-
     return this.agencies.some((row) => row.initials === managingAgency);
   }
 

--- a/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
+++ b/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
@@ -49,8 +49,12 @@ describe("Community Board Budget Request e2e", () => {
     });
 
     it("should 200 when finding by a valid cbbrNeedGroupId", async () => {
+      const cbbrNeedGroupId =
+        communityBoardBudgetRequestRepositoryMock.needGroupMocks[0].id;
       const response = await request(app.getHttpServer())
-        .get(`/community-board-budget-requests/policy-areas?cbbrNeedGroupId=5`)
+        .get(
+          `/community-board-budget-requests/policy-areas?cbbrNeedGroupId=${cbbrNeedGroupId}`,
+        )
         .expect(200);
       expect(() =>
         findCommunityBoardBudgetRequestPolicyAreasQueryResponseSchema.parse(
@@ -66,9 +70,10 @@ describe("Community Board Budget Request e2e", () => {
     });
 
     it("should 200 when finding by a valid agencyInitials", async () => {
+      const agencyInitials = agencyRepositoryMock.agencies[0].initials;
       const response = await request(app.getHttpServer())
         .get(
-          `/community-board-budget-requests/policy-areas?agencyInitials=DOHMH`,
+          `/community-board-budget-requests/policy-areas?agencyInitials=${agencyInitials}`,
         )
         .expect(200);
       expect(() =>
@@ -81,7 +86,7 @@ describe("Community Board Budget Request e2e", () => {
         findCommunityBoardBudgetRequestPolicyAreasQueryResponseSchema.parse(
           response.body,
         );
-      expect(parsedBody.cbbrPolicyAreas.length).toBe(1);
+      expect(parsedBody.cbbrPolicyAreas.length).toBe(4);
     });
 
     it("should 400 when finding by invalid cbbrNeedGroupId", async () => {
@@ -100,7 +105,7 @@ describe("Community Board Budget Request e2e", () => {
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
-    it("should 500 when the database errors", async () => {
+    it.only("should 500 when the database errors", async () => {
       const dataRetrievalException = new DataRetrievalException(
         "cannot find data",
       );

--- a/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
+++ b/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
@@ -97,25 +97,19 @@ describe("Community Board Budget Request e2e", () => {
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
-    it("should 400 when finding by invalid agencyInitials", async () => {
-      it("should 400 when finding by a missing cbbrNeedGroupId", async () => {
-        const response = await request(app.getHttpServer()).get(
-          "/community-board-budget-requests/policy-areas?cbbrNeedGroupId=0",
-        );
-        expect(response.body.message).toMatch(/Need group id does not exist/);
-        expect(response.body.error).toBe(HttpName.BAD_REQUEST);
-      });
-      it("should 400 when finding by a missing cbbrNeedGroupId", async () => {
-        const response = await request(app.getHttpServer()).get(
-          "/community-board-budget-requests/policy-areas?cbbrNeedGroupId=0",
-        );
-        expect(response.body.message).toMatch(/Need group id does not exist/);
-        expect(response.body.error).toBe(HttpName.BAD_REQUEST);
-      });
+    it("should 400 when finding by a missing cbbrNeedGroupId", async () => {
+      const response = await request(app.getHttpServer()).get(
+        "/community-board-budget-requests/policy-areas?cbbrNeedGroupId=0",
+      );
+      expect(response.body.message).toMatch(/Need group id does not exist/);
+      expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+    });
+
+    it("should 400 when finding by missing agencyInitials", async () => {
       const response = await request(app.getHttpServer()).get(
         "/community-board-budget-requests/policy-areas?agencyInitials=NONE",
       );
-      expect(response.body.message).toMatch(/Invalid agency initials/);
+      expect(response.body.message).toMatch(/Agency initials do not exist/);
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 

--- a/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
+++ b/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
@@ -98,6 +98,20 @@ describe("Community Board Budget Request e2e", () => {
     });
 
     it("should 400 when finding by invalid agencyInitials", async () => {
+      it("should 400 when finding by a missing cbbrNeedGroupId", async () => {
+        const response = await request(app.getHttpServer()).get(
+          "/community-board-budget-requests/policy-areas?cbbrNeedGroupId=0",
+        );
+        expect(response.body.message).toMatch(/Need group id does not exist/);
+        expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+      });
+      it("should 400 when finding by a missing cbbrNeedGroupId", async () => {
+        const response = await request(app.getHttpServer()).get(
+          "/community-board-budget-requests/policy-areas?cbbrNeedGroupId=0",
+        );
+        expect(response.body.message).toMatch(/Need group id does not exist/);
+        expect(response.body.error).toBe(HttpName.BAD_REQUEST);
+      });
       const response = await request(app.getHttpServer()).get(
         "/community-board-budget-requests/policy-areas?agencyInitials=NONE",
       );

--- a/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
+++ b/test/community-board-budget-request/community-board-budget-request.e2e-spec.ts
@@ -119,7 +119,7 @@ describe("Community Board Budget Request e2e", () => {
       expect(response.body.error).toBe(HttpName.BAD_REQUEST);
     });
 
-    it.only("should 500 when the database errors", async () => {
+    it("should 500 when the database errors", async () => {
       const dataRetrievalException = new DataRetrievalException(
         "cannot find data",
       );

--- a/test/community-board-budget-request/community-board-budget-request.repository.mock.ts
+++ b/test/community-board-budget-request/community-board-budget-request.repository.mock.ts
@@ -1,5 +1,8 @@
 import { generateMock } from "@anatine/zod-mock";
-import { FindPolicyAreasRepo } from "src/community-board-budget-request/community-board-budget-request.repository.schema";
+import {
+  CheckNeedGroupByIdRepo,
+  FindPolicyAreasRepo,
+} from "src/community-board-budget-request/community-board-budget-request.repository.schema";
 import {
   cbbrNeedGroupEntitySchema,
   CbbrPolicyAreaEntitySchema,
@@ -20,6 +23,10 @@ export class CommunityBoardBudgetRequestRepositoryMock {
   needGroupMocks = Array.from(Array(8), (_, i) =>
     generateMock(cbbrNeedGroupEntitySchema, { seed: i + 1 }),
   );
+
+  checkNeedGroupById(id: number): CheckNeedGroupByIdRepo {
+    return this.needGroupMocks.some((needGroup) => needGroup.id === id);
+  }
 
   get policyAreasCriteria(): Array<
     [


### PR DESCRIPTION
## Mocks
- substituting hand-written test data for auto-generated mock data
  - this enforces the shape and relationships of the data, without coupling it to the actual content
- construct mock cbbr options with data from other mock tables
- refactor mock findPolicyAreas
  - Update types from "null" to "undefined", to match the real function
  - Update the logical check to "escape when a policy area fails to meet a criteria"

## Missing agency message
- Update the "agency initials" error message to specificy that they're missing, which is the specific way they're invalid

## Missing need group id
- Add a check for missing need group ids.
  - Checks for agency initials and need group ids weren't part of the acceptance criteria of this ticket. I figured we could make them a follow-up ticket. But if the agency check and the cachemanager are already included and, then I thought I'd sneak in need group id, as well

## Additional test cases
- Add a service test for missing agency initials
- Add service and e2e tests from missing need group ids    
