### PR TITLE
489 Add /community-board-budget-requests/agencies endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -83,6 +83,8 @@ paths:
     $ref: paths/city-council-districts_{cityCouncilDistrictId}_capital-projects.yaml
   /city-council-districts/{z}/{x}/{y}.pbf:
     $ref: paths/city-council-districts_{z}_{x}_{y}.pbf.yaml
+  /community-board-budget-requests/agencies:
+    $ref: paths/community-board-budget-requests_agencies.yaml
   /community-board-budget-requests/need-groups:
     $ref: paths/community-board-budget-requests_need-groups.yaml
   /community-board-budget-requests/policy-areas:

--- a/openapi/paths/community-board-budget-requests_agencies.yaml
+++ b/openapi/paths/community-board-budget-requests_agencies.yaml
@@ -1,0 +1,26 @@
+get:
+  summary: Find community board budget request agencies
+  operationId: findCommunityBoardBudgetRequestAgencies
+  tags:
+    - Community Board Budget Requests
+  parameters:
+    - $ref: ../components/parameters/cbbrNeedGroupIdQueryParam.yaml
+    - $ref: ../components/parameters/cbbrPolicyAreaIdQueryParam.yaml
+  responses:
+    '200':
+      description: An object containing a list of agencies
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              cbbrAgencies:
+                type: array
+                items:
+                  $ref: ../components/schemas/Agency.yaml
+            required:
+              - cbbrAgencies
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/src/community-board-budget-request/community-board-budget-request.controller.ts
+++ b/src/community-board-budget-request/community-board-budget-request.controller.ts
@@ -5,6 +5,8 @@ import {
   findCommunityBoardBudgetRequestNeedGroupsQueryParamsSchema,
   FindCommunityBoardBudgetRequestPolicyAreasQueryParams,
   findCommunityBoardBudgetRequestPolicyAreasQueryParamsSchema,
+  FindCommunityBoardBudgetRequestAgenciesQueryParams,
+  findCommunityBoardBudgetRequestAgenciesQueryParamsSchema,
 } from "src/gen";
 import {
   BadRequestExceptionFilter,
@@ -24,6 +26,18 @@ export class CommunityBoardBudgetRequestController {
   constructor(
     private readonly communityBoardBudgetRequestService: CommunityBoardBudgetRequestService,
   ) {}
+
+  @Get("/agencies")
+  async findAgencies(
+    @Query(
+      new ZodTransformPipe(
+        findCommunityBoardBudgetRequestAgenciesQueryParamsSchema,
+      ),
+    )
+    queryParams: FindCommunityBoardBudgetRequestAgenciesQueryParams,
+  ) {
+    return this.communityBoardBudgetRequestService.findAgencies(queryParams);
+  }
 
   @Get("/need-groups")
   async findNeedGroups(

--- a/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
@@ -1,8 +1,13 @@
 import {
   cbbrPolicyAreaEntitySchema,
   cbbrNeedGroupEntitySchema,
+  agencyEntitySchema,
 } from "src/schema";
 import { z } from "zod";
+
+export const findAgencyRepoSchema = z.array(agencyEntitySchema);
+
+export type FindAgenciesRepo = z.infer<typeof findAgencyRepoSchema>;
 
 export const findNeedGroupRepoSchema = z.array(cbbrNeedGroupEntitySchema);
 

--- a/src/community-board-budget-request/community-board-budget-request.service.spec.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.spec.ts
@@ -3,6 +3,7 @@ import { Test } from "@nestjs/testing";
 import {
   findCommunityBoardBudgetRequestPolicyAreasQueryResponseSchema,
   findCommunityBoardBudgetRequestNeedGroupsQueryResponseSchema,
+  findCommunityBoardBudgetRequestAgenciesQueryResponseSchema,
 } from "src/gen";
 import { CommunityBoardBudgetRequestService } from "./community-board-budget-request.service";
 import { CommunityBoardBudgetRequestRepository } from "./community-board-budget-request.repository";
@@ -34,6 +35,64 @@ describe("Community Board Budget Request service unit", () => {
       moduleRef.get<CommunityBoardBudgetRequestService>(
         CommunityBoardBudgetRequestService,
       );
+  });
+
+  describe("findAgencies", () => {
+    it("should return a findCommunityBoardBudgetRequestAgenciesQueryResponseSchema compliant object", async () => {
+      const agencies = await communityBoardBudgetRequestService.findAgencies(
+        {},
+      );
+      expect(() =>
+        findCommunityBoardBudgetRequestAgenciesQueryResponseSchema.parse(
+          agencies,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should return the full list of agencies", async () => {
+      const agencies = await communityBoardBudgetRequestService.findAgencies(
+        {},
+      );
+      expect(agencies.cbbrAgencies.length).toBe(2);
+    });
+
+    it("should return an InvalidRequestParameter error when a policy area with the given id cannot be found", async () => {
+      const cbbrPolicyAreaId = 0;
+
+      expect(
+        communityBoardBudgetRequestService.findAgencies({
+          cbbrPolicyAreaId,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
+    it("should filter agencies by cbbrPolicyAreaId", async () => {
+      const { id: policyAreaId } =
+        communityBoardBudgetRequestRepositoryMock.policyAreaMocks[0];
+      const agencies = await communityBoardBudgetRequestService.findAgencies({
+        cbbrPolicyAreaId: policyAreaId,
+      });
+      expect(agencies.cbbrAgencies.length).toBe(1);
+    });
+
+    it("should return an InvalidRequestParameter error when a need group with the given id cannot be found", async () => {
+      const cbbrNeedGroupId = 0;
+
+      expect(
+        communityBoardBudgetRequestService.findAgencies({
+          cbbrNeedGroupId,
+        }),
+      ).rejects.toThrow(InvalidRequestParameterException);
+    });
+
+    it("should filter agencies by cbbrNeedGroupId", async () => {
+      const { id: needGroupId } =
+        communityBoardBudgetRequestRepositoryMock.needGroupMocks[0];
+      const agencies = await communityBoardBudgetRequestService.findAgencies({
+        cbbrNeedGroupId: needGroupId,
+      });
+      expect(agencies.cbbrAgencies.length).toBe(1);
+    });
   });
 
   describe("findNeedGroups", () => {

--- a/src/community-board-budget-request/community-board-budget-request.service.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { CommunityBoardBudgetRequestRepository } from "./community-board-budget-request.repository";
 import {
+  FindCommunityBoardBudgetRequestAgenciesQueryParams,
   FindCommunityBoardBudgetRequestNeedGroupsQueryParams,
   FindCommunityBoardBudgetRequestPolicyAreasQueryParams,
 } from "src/gen";
@@ -14,6 +15,42 @@ export class CommunityBoardBudgetRequestService {
     private readonly communityBoardBudgetRequestRepository: CommunityBoardBudgetRequestRepository,
     private readonly agencyRepository: AgencyRepository,
   ) {}
+
+  async findAgencies({
+    cbbrPolicyAreaId,
+    cbbrNeedGroupId,
+  }: FindCommunityBoardBudgetRequestAgenciesQueryParams) {
+    if (cbbrNeedGroupId !== undefined) {
+      const checkNeedGroupId =
+        await this.communityBoardBudgetRequestRepository.checkNeedGroupById(
+          cbbrNeedGroupId,
+        );
+      if (checkNeedGroupId === false)
+        throw new InvalidRequestParameterException(
+          "Need group id does not exist",
+        );
+    }
+
+    if (cbbrPolicyAreaId !== undefined) {
+      const checkPolicyAreaId =
+        await this.communityBoardBudgetRequestRepository.checkPolicyAreaById(
+          cbbrPolicyAreaId,
+        );
+      if (checkPolicyAreaId === false)
+        throw new InvalidRequestParameterException(
+          "Policy area id does not exist",
+        );
+    }
+
+    const cbbrAgencies =
+      await this.communityBoardBudgetRequestRepository.findAgencies({
+        cbbrPolicyAreaId,
+        cbbrNeedGroupId,
+      });
+    return {
+      cbbrAgencies,
+    };
+  }
 
   async findNeedGroups({
     cbbrPolicyAreaId,

--- a/src/gen/types/FindCommunityBoardBudgetRequestAgencies.ts
+++ b/src/gen/types/FindCommunityBoardBudgetRequestAgencies.ts
@@ -1,0 +1,48 @@
+import type { Agency } from "./Agency";
+import type { Error } from "./Error";
+
+export type FindCommunityBoardBudgetRequestAgenciesQueryParams = {
+  /**
+   * @description The number used to refer to the need group.
+   * @type integer | undefined
+   */
+  cbbrNeedGroupId?: number;
+  /**
+   * @description The number used to refer to the policy area.
+   * @type integer | undefined
+   */
+  cbbrPolicyAreaId?: number;
+};
+/**
+ * @description An object containing a list of agencies
+ */
+export type FindCommunityBoardBudgetRequestAgencies200 = {
+  /**
+   * @type array
+   */
+  cbbrAgencies: Agency[];
+};
+/**
+ * @description Invalid client request
+ */
+export type FindCommunityBoardBudgetRequestAgencies400 = Error;
+/**
+ * @description Server side error
+ */
+export type FindCommunityBoardBudgetRequestAgencies500 = Error;
+/**
+ * @description An object containing a list of agencies
+ */
+export type FindCommunityBoardBudgetRequestAgenciesQueryResponse = {
+  /**
+   * @type array
+   */
+  cbbrAgencies: Agency[];
+};
+export type FindCommunityBoardBudgetRequestAgenciesQuery = {
+  Response: FindCommunityBoardBudgetRequestAgenciesQueryResponse;
+  QueryParams: FindCommunityBoardBudgetRequestAgenciesQueryParams;
+  Errors:
+    | FindCommunityBoardBudgetRequestAgencies400
+    | FindCommunityBoardBudgetRequestAgencies500;
+};

--- a/src/gen/types/index.ts
+++ b/src/gen/types/index.ts
@@ -32,6 +32,7 @@ export * from "./FindCapitalProjectsByCityCouncilId";
 export * from "./FindCityCouncilDistrictGeoJsonByCityCouncilDistrictId";
 export * from "./FindCityCouncilDistrictTiles";
 export * from "./FindCityCouncilDistricts";
+export * from "./FindCommunityBoardBudgetRequestAgencies";
 export * from "./FindCommunityBoardBudgetRequestNeedGroups";
 export * from "./FindCommunityBoardBudgetRequestPolicyAreas";
 export * from "./FindCommunityDistrictGeoJsonByBoroughIdCommunityDistrictId";

--- a/src/gen/zod/findCommunityBoardBudgetRequestAgenciesSchema.ts
+++ b/src/gen/zod/findCommunityBoardBudgetRequestAgenciesSchema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { agencySchema } from "./agencySchema";
+import { errorSchema } from "./errorSchema";
+
+export const findCommunityBoardBudgetRequestAgenciesQueryParamsSchema = z
+  .object({
+    cbbrNeedGroupId: z.coerce
+      .number()
+      .int()
+      .describe("The number used to refer to the need group.")
+      .optional(),
+    cbbrPolicyAreaId: z.coerce
+      .number()
+      .int()
+      .describe("The number used to refer to the policy area.")
+      .optional(),
+  })
+  .optional();
+/**
+ * @description An object containing a list of agencies
+ */
+export const findCommunityBoardBudgetRequestAgencies200Schema = z.object({
+  cbbrAgencies: z.array(z.lazy(() => agencySchema)),
+});
+/**
+ * @description Invalid client request
+ */
+export const findCommunityBoardBudgetRequestAgencies400Schema = z.lazy(
+  () => errorSchema,
+);
+/**
+ * @description Server side error
+ */
+export const findCommunityBoardBudgetRequestAgencies500Schema = z.lazy(
+  () => errorSchema,
+);
+/**
+ * @description An object containing a list of agencies
+ */
+export const findCommunityBoardBudgetRequestAgenciesQueryResponseSchema =
+  z.object({ cbbrAgencies: z.array(z.lazy(() => agencySchema)) });

--- a/src/gen/zod/index.ts
+++ b/src/gen/zod/index.ts
@@ -32,6 +32,7 @@ export * from "./findCapitalProjectsSchema";
 export * from "./findCityCouncilDistrictGeoJsonByCityCouncilDistrictIdSchema";
 export * from "./findCityCouncilDistrictTilesSchema";
 export * from "./findCityCouncilDistrictsSchema";
+export * from "./findCommunityBoardBudgetRequestAgenciesSchema";
 export * from "./findCommunityBoardBudgetRequestNeedGroupsSchema";
 export * from "./findCommunityBoardBudgetRequestPolicyAreasSchema";
 export * from "./findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdSchema";

--- a/src/gen/zod/operations.ts
+++ b/src/gen/zod/operations.ts
@@ -110,6 +110,12 @@ import {
   findCityCouncilDistrictTilesPathParamsSchema,
 } from "./findCityCouncilDistrictTilesSchema";
 import {
+  findCommunityBoardBudgetRequestAgenciesQueryResponseSchema,
+  findCommunityBoardBudgetRequestAgencies400Schema,
+  findCommunityBoardBudgetRequestAgencies500Schema,
+  findCommunityBoardBudgetRequestAgenciesQueryParamsSchema,
+} from "./findCommunityBoardBudgetRequestAgenciesSchema";
+import {
   findCommunityBoardBudgetRequestNeedGroupsQueryResponseSchema,
   findCommunityBoardBudgetRequestNeedGroups400Schema,
   findCommunityBoardBudgetRequestNeedGroups500Schema,
@@ -543,6 +549,24 @@ export const operations = {
       500: findCityCouncilDistrictTiles500Schema,
     },
   },
+  findCommunityBoardBudgetRequestAgencies: {
+    request: undefined,
+    parameters: {
+      path: undefined,
+      query: findCommunityBoardBudgetRequestAgenciesQueryParamsSchema,
+      header: undefined,
+    },
+    responses: {
+      200: findCommunityBoardBudgetRequestAgenciesQueryResponseSchema,
+      400: findCommunityBoardBudgetRequestAgencies400Schema,
+      500: findCommunityBoardBudgetRequestAgencies500Schema,
+      default: findCommunityBoardBudgetRequestAgenciesQueryResponseSchema,
+    },
+    errors: {
+      400: findCommunityBoardBudgetRequestAgencies400Schema,
+      500: findCommunityBoardBudgetRequestAgencies500Schema,
+    },
+  },
   findCommunityBoardBudgetRequestNeedGroups: {
     request: undefined,
     parameters: {
@@ -870,6 +894,9 @@ export const paths = {
   },
   "/city-council-districts/{z}/{x}/{y}.pbf": {
     get: operations["findCityCouncilDistrictTiles"],
+  },
+  "/community-board-budget-requests/agencies": {
+    get: operations["findCommunityBoardBudgetRequestAgencies"],
   },
   "/community-board-budget-requests/need-groups": {
     get: operations["findCommunityBoardBudgetRequestNeedGroups"],


### PR DESCRIPTION
### `/community-board-budget-requests/agencies`
- operationId: findCommunityBoardBudgetRequestAgencies
- Response codes
  - 200
  - 400
  - 500 
- query parameters
  - cbbrPolicyAreaId, integer, optional
  - cbbrNeedGroupId, integer, optional
- response body
  - initials, string, required
  - name, string, required

## Acceptance Criteria
Update the OpenAPI docs:
- [x] Add /community-board-budget-requests/agencies path

Create the endpoint:
Endpoint should be `/community-board-budget-requests/agencies`.
- [x] Endpoint should be reflected in OpenAPI spec (regenerate files as needed)
- [x] Add tests for new endpoint

Completes #489 