### PR TITLE
476/budget request tiles

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -95,6 +95,8 @@ paths:
     $ref: paths/community-board-budget-requests_need-groups.yaml
   /community-board-budget-requests/policy-areas:
     $ref: paths/community-board-budget-requests_policy-areas.yaml
+  /community-board-budget-requests/{z}/{x}/{y}.pbf:
+    $ref: paths/community-board-budget-requests_{z}_{x}_{y}.pbf.yaml
   /community-districts/{z}/{x}/{y}.pbf:
     $ref: paths/community-districts_{z}_{x}_{y}.pbf.yaml
   /land-uses:

--- a/openapi/paths/community-board-budget-requests_{z}_{x}_{y}.pbf.yaml
+++ b/openapi/paths/community-board-budget-requests_{z}_{x}_{y}.pbf.yaml
@@ -1,0 +1,17 @@
+get:
+  summary: Mapbox Vector Tiles for community board budget requests
+  operationId: findCommunityBoardBudgetRequestTiles
+  tags:
+    - MVT
+    - Community Board Budget Requests
+  parameters:
+    - $ref: ../components/parameters/viewportZoomParam.yaml
+    - $ref: ../components/parameters/viewportXParam.yaml
+    - $ref: ../components/parameters/viewportYParam.yaml
+  responses:
+    '200':
+      $ref: ../components/responses/MVT.yaml
+    '400':
+      $ref: ../components/responses/BadRequest.yaml
+    '500':
+      $ref: ../components/responses/InternalServerError.yaml

--- a/src/community-board-budget-request/community-board-budget-request.controller.ts
+++ b/src/community-board-budget-request/community-board-budget-request.controller.ts
@@ -4,8 +4,11 @@ import {
   Injectable,
   Param,
   Query,
+  Res,
   UseFilters,
+  UsePipes,
 } from "@nestjs/common";
+import { Response } from "express";
 import { CommunityBoardBudgetRequestService } from "./community-board-budget-request.service";
 import {
   FindCommunityBoardBudgetRequestNeedGroupsQueryParams,
@@ -17,6 +20,8 @@ import {
   FindCommunityBoardBudgetRequestByIdPathParams,
   findCommunityBoardBudgetRequestsQueryParamsSchema,
   FindCommunityBoardBudgetRequestsQueryParams,
+  findCommunityBoardBudgetRequestTilesPathParamsSchema,
+  FindCommunityBoardBudgetRequestTilesPathParams,
 } from "src/gen";
 import {
   BadRequestExceptionFilter,
@@ -117,5 +122,19 @@ export class CommunityBoardBudgetRequestController {
     @Param() params: FindCommunityBoardBudgetRequestByIdPathParams,
   ) {
     return this.communityBoardBudgetRequestService.findById(params);
+  }
+
+  @UsePipes(
+    new ZodTransformPipe(findCommunityBoardBudgetRequestTilesPathParamsSchema),
+  )
+  @Get("/:z/:x/:y.pbf")
+  async findTiles(
+    @Param() params: FindCommunityBoardBudgetRequestTilesPathParams,
+    @Res() res: Response,
+  ) {
+    const tile =
+      await this.communityBoardBudgetRequestService.findTiles(params);
+    res.set("Content-Type", "application/x-protobuf");
+    res.send(tile);
   }
 }

--- a/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
@@ -3,6 +3,7 @@ import {
   cbbrNeedGroupEntitySchema,
   agencyEntitySchema,
   cbbrAgencyCategoryResponseEntitySchema,
+  mvtEntitySchema,
 } from "src/schema";
 import { z } from "zod";
 
@@ -91,3 +92,7 @@ export const checkAgencyResponseTypeByIdRepoSchema = z.boolean();
 export type CheckAgencyResponseTypeByIdRepo = z.infer<
   typeof checkAgencyResponseTypeByIdRepoSchema
 >;
+
+export const findTilesRepoSchema = mvtEntitySchema;
+
+export type FindTilesRepo = z.infer<typeof findTilesRepoSchema>;

--- a/src/community-board-budget-request/community-board-budget-request.service.spec.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.spec.ts
@@ -7,6 +7,7 @@ import {
   findCommunityBoardBudgetRequestByIdQueryResponseSchema,
   findCommunityBoardBudgetRequestsQueryResponseSchema,
   findCommunityBoardBudgetRequestAgencyResponseTypesQueryResponseSchema,
+  findCommunityBoardBudgetRequestTilesQueryResponseSchema,
 } from "src/gen";
 import { CommunityBoardBudgetRequestService } from "./community-board-budget-request.service";
 import { CommunityBoardBudgetRequestRepository } from "./community-board-budget-request.repository";
@@ -563,6 +564,19 @@ describe("Community Board Budget Request service unit", () => {
       const agencyResponseTypes =
         await communityBoardBudgetRequestService.findAgencyResponseTypes();
       expect(agencyResponseTypes.cbbrAgencyResponseTypes.length).toBe(6);
+    });
+  });
+
+  describe("findTiles", () => {
+    it("should return an mvt when requesting coordinates", async () => {
+      const mvt = await communityBoardBudgetRequestService.findTiles({
+        z: 1,
+        x: 1,
+        y: 1,
+      });
+      expect(() =>
+        findCommunityBoardBudgetRequestTilesQueryResponseSchema.parse(mvt),
+      ).not.toThrow();
     });
   });
 });

--- a/src/community-board-budget-request/community-board-budget-request.service.ts
+++ b/src/community-board-budget-request/community-board-budget-request.service.ts
@@ -6,6 +6,7 @@ import {
   FindCommunityBoardBudgetRequestByIdPathParams,
   FindCommunityBoardBudgetRequestNeedGroupsQueryParams,
   FindCommunityBoardBudgetRequestPolicyAreasQueryParams,
+  FindCommunityBoardBudgetRequestTilesPathParams,
 } from "src/gen";
 import { AgencyRepository } from "src/agency/agency.repository";
 import {
@@ -276,5 +277,9 @@ export class CommunityBoardBudgetRequestService {
     const cbbrAgencyResponseTypes =
       await this.communityBoardBudgetRequestRepository.findAgencyResponseTypes();
     return { cbbrAgencyResponseTypes };
+  }
+
+  async findTiles(params: FindCommunityBoardBudgetRequestTilesPathParams) {
+    return await this.communityBoardBudgetRequestRepository.findTiles(params);
   }
 }

--- a/src/gen/types/FindCommunityBoardBudgetRequestTiles.ts
+++ b/src/gen/types/FindCommunityBoardBudgetRequestTiles.ts
@@ -1,0 +1,42 @@
+import type { Error } from "./Error";
+
+export type FindCommunityBoardBudgetRequestTilesPathParams = {
+  /**
+   * @description viewport zoom component
+   * @type integer
+   */
+  z: number;
+  /**
+   * @description viewport x component
+   * @type integer
+   */
+  x: number;
+  /**
+   * @description viewport y component
+   * @type integer
+   */
+  y: number;
+};
+/**
+ * @description A protobuf file formatted as Mapbox Vector Tile
+ */
+export type FindCommunityBoardBudgetRequestTiles200 = string;
+/**
+ * @description Invalid client request
+ */
+export type FindCommunityBoardBudgetRequestTiles400 = Error;
+/**
+ * @description Server side error
+ */
+export type FindCommunityBoardBudgetRequestTiles500 = Error;
+/**
+ * @description A protobuf file formatted as Mapbox Vector Tile
+ */
+export type FindCommunityBoardBudgetRequestTilesQueryResponse = string;
+export type FindCommunityBoardBudgetRequestTilesQuery = {
+  Response: FindCommunityBoardBudgetRequestTilesQueryResponse;
+  PathParams: FindCommunityBoardBudgetRequestTilesPathParams;
+  Errors:
+    | FindCommunityBoardBudgetRequestTiles400
+    | FindCommunityBoardBudgetRequestTiles500;
+};

--- a/src/gen/types/index.ts
+++ b/src/gen/types/index.ts
@@ -42,6 +42,7 @@ export * from "./FindCommunityBoardBudgetRequestById";
 export * from "./FindCommunityBoardBudgetRequestNeedGroups";
 export * from "./FindCommunityBoardBudgetRequestPolicyAreas";
 export * from "./FindCommunityBoardBudgetRequests";
+export * from "./FindCommunityBoardBudgetRequestTiles";
 export * from "./FindCommunityDistrictGeoJsonByBoroughIdCommunityDistrictId";
 export * from "./FindCommunityDistrictTiles";
 export * from "./FindCommunityDistrictsByBoroughId";

--- a/src/gen/zod/findCommunityBoardBudgetRequestTilesSchema.ts
+++ b/src/gen/zod/findCommunityBoardBudgetRequestTilesSchema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { errorSchema } from "./errorSchema";
+
+export const findCommunityBoardBudgetRequestTilesPathParamsSchema = z.object({
+  z: z.coerce.number().int().describe("viewport zoom component"),
+  x: z.coerce.number().int().describe("viewport x component"),
+  y: z.coerce.number().int().describe("viewport y component"),
+});
+/**
+ * @description A protobuf file formatted as Mapbox Vector Tile
+ */
+export const findCommunityBoardBudgetRequestTiles200Schema = z.coerce.string();
+/**
+ * @description Invalid client request
+ */
+export const findCommunityBoardBudgetRequestTiles400Schema = z.lazy(
+  () => errorSchema,
+);
+/**
+ * @description Server side error
+ */
+export const findCommunityBoardBudgetRequestTiles500Schema = z.lazy(
+  () => errorSchema,
+);
+/**
+ * @description A protobuf file formatted as Mapbox Vector Tile
+ */
+export const findCommunityBoardBudgetRequestTilesQueryResponseSchema =
+  z.coerce.string();

--- a/src/gen/zod/index.ts
+++ b/src/gen/zod/index.ts
@@ -42,6 +42,7 @@ export * from "./findCommunityBoardBudgetRequestByIdSchema";
 export * from "./findCommunityBoardBudgetRequestNeedGroupsSchema";
 export * from "./findCommunityBoardBudgetRequestPolicyAreasSchema";
 export * from "./findCommunityBoardBudgetRequestsSchema";
+export * from "./findCommunityBoardBudgetRequestTilesSchema";
 export * from "./findCommunityDistrictGeoJsonByBoroughIdCommunityDistrictIdSchema";
 export * from "./findCommunityDistrictTilesSchema";
 export * from "./findCommunityDistrictsByBoroughIdSchema";

--- a/src/gen/zod/operations.ts
+++ b/src/gen/zod/operations.ts
@@ -146,6 +146,12 @@ import {
   findCommunityBoardBudgetRequestPolicyAreasQueryParamsSchema,
 } from "./findCommunityBoardBudgetRequestPolicyAreasSchema";
 import {
+  findCommunityBoardBudgetRequestTilesQueryResponseSchema,
+  findCommunityBoardBudgetRequestTiles400Schema,
+  findCommunityBoardBudgetRequestTiles500Schema,
+  findCommunityBoardBudgetRequestTilesPathParamsSchema,
+} from "./findCommunityBoardBudgetRequestTilesSchema";
+import {
   findCommunityDistrictTilesQueryResponseSchema,
   findCommunityDistrictTiles400Schema,
   findCommunityDistrictTiles500Schema,
@@ -678,6 +684,24 @@ export const operations = {
       500: findCommunityBoardBudgetRequestPolicyAreas500Schema,
     },
   },
+  findCommunityBoardBudgetRequestTiles: {
+    request: undefined,
+    parameters: {
+      path: findCommunityBoardBudgetRequestTilesPathParamsSchema,
+      query: undefined,
+      header: undefined,
+    },
+    responses: {
+      200: findCommunityBoardBudgetRequestTilesQueryResponseSchema,
+      400: findCommunityBoardBudgetRequestTiles400Schema,
+      500: findCommunityBoardBudgetRequestTiles500Schema,
+      default: findCommunityBoardBudgetRequestTilesQueryResponseSchema,
+    },
+    errors: {
+      400: findCommunityBoardBudgetRequestTiles400Schema,
+      500: findCommunityBoardBudgetRequestTiles500Schema,
+    },
+  },
   findCommunityDistrictTiles: {
     request: undefined,
     parameters: {
@@ -987,6 +1011,9 @@ export const paths = {
   },
   "/community-board-budget-requests/policy-areas": {
     get: operations["findCommunityBoardBudgetRequestPolicyAreas"],
+  },
+  "/community-board-budget-requests/{z}/{x}/{y}.pbf": {
+    get: operations["findCommunityBoardBudgetRequestTiles"],
   },
   "/community-districts/{z}/{x}/{y}.pbf": {
     get: operations["findCommunityDistrictTiles"],

--- a/test/community-board-budget-request/community-board-budget-request.repository.mock.ts
+++ b/test/community-board-budget-request/community-board-budget-request.repository.mock.ts
@@ -12,6 +12,8 @@ import {
   CheckAgencyResponseTypeByIdRepo,
   findManyCommunityBoardBudgetRequestEntitySchema,
   FindManyCommunityBoardBudgetRequestEntity,
+  FindTilesRepo,
+  findTilesRepoSchema,
 } from "src/community-board-budget-request/community-board-budget-request.repository.schema";
 import {
   CbbrNeedGroupEntitySchema,
@@ -384,5 +386,22 @@ export class CommunityBoardBudgetRequestRepositoryMock {
     const cbbrs = await this.filterCommunityBoardBudgetRequests(params);
 
     return cbbrs.length;
+  }
+
+  findTilesMock = generateMock(findTilesRepoSchema);
+
+  /**
+   * The database will always return tiles,
+   * even when the view is outside the extents.
+   * These would merely be empty tiles.
+   *
+   * To reflect this behavior in the mock,
+   * we disregard any viewport parameters and
+   * always return something.
+   *
+   * This applies to all mvt-related mocks
+   */
+  async findTiles(): Promise<FindTilesRepo> {
+    return this.findTilesMock;
   }
 }


### PR DESCRIPTION
The budget request tile requests as described in #476 

closes #476 

## For testing
There is a frontend branch useful for testing [ae-zoning-api/476/cbbr-tiles](https://github.com/NYCPlanning/ae-cp-map/tree/ae-zoning-api/476/cbbr-tiles)