### PR TITLE
Add request type to budget request tiles

### DIFF
--- a/src/city-council-district/city-council-district.repository.ts
+++ b/src/city-council-district/city-council-district.repository.ts
@@ -223,6 +223,9 @@ export class CityCouncilDistrictRepository {
             sql`${borough.abbr} || ${communityBoardBudgetRequest.communityDistrictId}`.as(
               "communityBoardId",
             ),
+          requestType: sql`${communityBoardBudgetRequest.requestType}`.as(
+            "requestType",
+          ),
           geomFill: sql<string>`
               CASE
                 WHEN ${communityBoardBudgetRequest.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})

--- a/src/community-board-budget-request/community-board-budget-request.repository.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.ts
@@ -698,6 +698,9 @@ export class CommunityBoardBudgetRequestRepository {
             sql`${borough.abbr} || ${communityBoardBudgetRequest.communityDistrictId}`.as(
               "communityBoardId",
             ),
+          requestType: sql`${communityBoardBudgetRequest.requestType}`.as(
+            "requestType",
+          ),
           geomFill: sql<string>`
                 CASE
                   WHEN ${communityBoardBudgetRequest.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})


### PR DESCRIPTION
- Add community board budget request type to tiles, allowing frontend to filter on request type
- Add missing spatial check to community district tile endpoint

closes NYCPlanning/ae-cp-map#302