### PR TITLE
Add spatial columns to boroughs

### DIFF
--- a/db/migration/0029_new_morlocks.sql
+++ b/db/migration/0029_new_morlocks.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "borough" ADD COLUMN "li_ft" geometry(multiPolygon,2263);--> statement-breakpoint
+ALTER TABLE "borough" ADD COLUMN "mercator_fill" geometry(multiPolygon,3857);--> statement-breakpoint
+ALTER TABLE "borough" ADD COLUMN "mercator_label" geometry(point,3857);

--- a/db/migration/meta/0029_snapshot.json
+++ b/db/migration/meta/0029_snapshot.json
@@ -1,0 +1,1829 @@
+{
+  "id": "20208b4c-294e-43d8-8b43-ce43c41c0361",
+  "prevId": "7f5abfa5-d8fc-4fa4-9ed0-f7fd0a19dad1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agency_budget": {
+      "name": "agency_budget",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agency_budget_sponsor_agency_initials_fk": {
+          "name": "agency_budget_sponsor_agency_initials_fk",
+          "tableFrom": "agency_budget",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "sponsor"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agency": {
+      "name": "agency",
+      "schema": "",
+      "columns": {
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.borough": {
+      "name": "borough",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(1)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbr": {
+          "name": "abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_line": {
+      "name": "budget_line",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_line_code_agency_budget_code_fk": {
+          "name": "budget_line_code_agency_budget_code_fk",
+          "tableFrom": "budget_line",
+          "tableTo": "agency_budget",
+          "columnsFrom": [
+            "code"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "budget_line_code_id_pk": {
+          "name": "budget_line_code_id_pk",
+          "columns": [
+            "code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment_fund": {
+      "name": "capital_commitment_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capital_commitment_id": {
+          "name": "capital_commitment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk": {
+          "name": "capital_commitment_fund_capital_commitment_id_capital_commitment_id_fk",
+          "tableFrom": "capital_commitment_fund",
+          "tableTo": "capital_commitment",
+          "columnsFrom": [
+            "capital_commitment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_commitment_fund_capital_fund_category": {
+          "name": "capital_commitment_fund_capital_fund_category",
+          "value": "\"capital_commitment_fund\".\"capital_fund_category\" IN ('city-non-exempt', 'city-exempt', 'city-cost', 'non-city-state', 'non-city-federal', 'non-city-other', 'non-city-cost', 'total')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment_type": {
+      "name": "capital_commitment_type",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "char(4)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_commitment": {
+      "name": "capital_commitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "char(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_date": {
+          "name": "planned_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_line_code": {
+          "name": "budget_line_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_line_id": {
+          "name": "budget_line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "capital_commitment_type_capital_commitment_type_code_fk": {
+          "name": "capital_commitment_type_capital_commitment_type_code_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_commitment_type",
+          "columnsFrom": [
+            "type"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk": {
+          "name": "capital_commitment_managing_code_capital_project_id_capital_project_managing_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk": {
+          "name": "capital_commitment_budget_line_code_budget_line_id_budget_line_code_id_fk",
+          "tableFrom": "capital_commitment",
+          "tableTo": "budget_line",
+          "columnsFrom": [
+            "budget_line_code",
+            "budget_line_id"
+          ],
+          "columnsTo": [
+            "code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_project_checkbook": {
+      "name": "capital_project_checkbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_checkbook",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capital_project_fund": {
+      "name": "capital_project_fund",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_project_id": {
+          "name": "capital_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capital_fund_category": {
+          "name": "capital_fund_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "custom_fk": {
+          "name": "custom_fk",
+          "tableFrom": "capital_project_fund",
+          "tableTo": "capital_project",
+          "columnsFrom": [
+            "managing_code",
+            "capital_project_id"
+          ],
+          "columnsTo": [
+            "managing_code",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_project_fund_stage_options": {
+          "name": "capital_project_fund_stage_options",
+          "value": "\"capital_project_fund\".\"stage\" IN ('adopt', 'allocate', 'commit', 'spent')"
+        },
+        "capital_project_fund_capital_fund_category": {
+          "name": "capital_project_fund_capital_fund_category",
+          "value": "\"capital_project_fund\".\"capital_fund_category\" IN ('city-non-exempt', 'city-exempt', 'city-cost', 'non-city-state', 'non-city-federal', 'non-city-other', 'non-city-cost', 'total')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.capital_project": {
+      "name": "capital_project",
+      "schema": "",
+      "columns": {
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_agency": {
+          "name": "managing_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_date": {
+          "name": "min_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_date": {
+          "name": "max_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_pnt": {
+          "name": "li_ft_m_pnt",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_poly": {
+          "name": "li_ft_m_poly",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_pnt": {
+          "name": "mercator_fill_m_pnt",
+          "type": "geometry(multiPoint,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_poly": {
+          "name": "mercator_fill_m_poly",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "capital_project_mercator_fill_m_poly_index": {
+          "name": "capital_project_mercator_fill_m_poly_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_mercator_fill_m_pnt_index": {
+          "name": "capital_project_mercator_fill_m_pnt_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_pnt_index": {
+          "name": "capital_project_li_ft_m_pnt_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "capital_project_li_ft_m_poly_index": {
+          "name": "capital_project_li_ft_m_poly_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capital_project_managing_code_managing_code_id_fk": {
+          "name": "capital_project_managing_code_managing_code_id_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "managing_code",
+          "columnsFrom": [
+            "managing_code"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capital_project_managing_agency_agency_initials_fk": {
+          "name": "capital_project_managing_agency_agency_initials_fk",
+          "tableFrom": "capital_project",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "managing_agency"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "capital_project_managing_code_id_pk": {
+          "name": "capital_project_managing_code_id_pk",
+          "columns": [
+            "managing_code",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capital_project_category_options": {
+          "name": "capital_project_category_options",
+          "value": "\"capital_project\".\"category\" IN (\n          'Fixed Asset',\n          'Lump Sum',\n          'ITT, Vehicles, and Equipment'\n          )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.city_council_district": {
+      "name": "city_council_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "city_council_district_mercator_fill_index": {
+          "name": "city_council_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_mercator_label_index": {
+          "name": "city_council_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "city_council_district_li_ft_index": {
+          "name": "city_council_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbbr_agency_category_response": {
+      "name": "cbbr_agency_category_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cbbr_agency_category_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "32767",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbbr_need": {
+      "name": "cbbr_need",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cbbr_need_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "32767",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbbr_need_group": {
+      "name": "cbbr_need_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cbbr_need_group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "32767",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbbr_option_cascade": {
+      "name": "cbbr_option_cascade",
+      "schema": "",
+      "columns": {
+        "policy_area_id": {
+          "name": "policy_area_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_group_id": {
+          "name": "need_group_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency_initials": {
+          "name": "agency_initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_id": {
+          "name": "need_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cbbr_option_cascade_policy_area_id_cbbr_policy_area_id_fk": {
+          "name": "cbbr_option_cascade_policy_area_id_cbbr_policy_area_id_fk",
+          "tableFrom": "cbbr_option_cascade",
+          "tableTo": "cbbr_policy_area",
+          "columnsFrom": [
+            "policy_area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cbbr_option_cascade_need_group_id_cbbr_need_group_id_fk": {
+          "name": "cbbr_option_cascade_need_group_id_cbbr_need_group_id_fk",
+          "tableFrom": "cbbr_option_cascade",
+          "tableTo": "cbbr_need_group",
+          "columnsFrom": [
+            "need_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cbbr_option_cascade_agency_initials_agency_initials_fk": {
+          "name": "cbbr_option_cascade_agency_initials_agency_initials_fk",
+          "tableFrom": "cbbr_option_cascade",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "agency_initials"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cbbr_option_cascade_need_id_cbbr_need_id_fk": {
+          "name": "cbbr_option_cascade_need_id_cbbr_need_id_fk",
+          "tableFrom": "cbbr_option_cascade",
+          "tableTo": "cbbr_need",
+          "columnsFrom": [
+            "need_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cbbr_option_cascade_request_id_cbbr_request_id_fk": {
+          "name": "cbbr_option_cascade_request_id_cbbr_request_id_fk",
+          "tableFrom": "cbbr_option_cascade",
+          "tableTo": "cbbr_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cbbr_request_type_options": {
+          "name": "cbbr_request_type_options",
+          "value": "\"cbbr_option_cascade\".\"type\" IN ('Capital', 'Expense')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cbbr_policy_area": {
+      "name": "cbbr_policy_area",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cbbr_policy_area_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "32767",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbbr_request": {
+      "name": "cbbr_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "cbbr_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "32767",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_board_budget_request": {
+      "name": "community_board_budget_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_district_id": {
+          "name": "community_district_id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managing_code": {
+          "name": "managing_code",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency_category_response_id": {
+          "name": "agency_category_response_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_response": {
+          "name": "agency_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_area_id": {
+          "name": "policy_area_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_group_id": {
+          "name": "need_group_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_id": {
+          "name": "need_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_on_street": {
+          "name": "segment_on_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_cross_street_one": {
+          "name": "segment_cross_street_one",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_cross_street_two": {
+          "name": "segment_cross_street_two",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intersection_street_one": {
+          "name": "intersection_street_one",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intersection_street_two": {
+          "name": "intersection_street_two",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_location_specific": {
+          "name": "is_location_specific",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_continued_support": {
+          "name": "is_continued_support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft_m_pnt": {
+          "name": "li_ft_m_pnt",
+          "type": "geometry(multiPoint,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "li_ft_m_poly": {
+          "name": "li_ft_m_poly",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_pnt": {
+          "name": "mercator_fill_m_pnt",
+          "type": "geometry(multiPoint,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill_m_poly": {
+          "name": "mercator_fill_m_poly",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_board_budget_request_li_ft_m_pnt_index": {
+          "name": "community_board_budget_request_li_ft_m_pnt_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_board_budget_request_li_ft_m_poly_index": {
+          "name": "community_board_budget_request_li_ft_m_poly_index",
+          "columns": [
+            {
+              "expression": "li_ft_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_board_budget_request_mercator_label_index": {
+          "name": "community_board_budget_request_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_board_budget_request_mercator_fill_m_poly_index": {
+          "name": "community_board_budget_request_mercator_fill_m_poly_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_poly",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_board_budget_request_mercator_fill_m_pnt_index": {
+          "name": "community_board_budget_request_mercator_fill_m_pnt_index",
+          "columns": [
+            {
+              "expression": "mercator_fill_m_pnt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_board_budget_request_agency_agency_initials_fk": {
+          "name": "community_board_budget_request_agency_agency_initials_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "agency",
+          "columnsFrom": [
+            "agency"
+          ],
+          "columnsTo": [
+            "initials"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_managing_code_managing_code_id_fk": {
+          "name": "community_board_budget_request_managing_code_managing_code_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "managing_code",
+          "columnsFrom": [
+            "managing_code"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_agency_category_response_id_cbbr_agency_category_response_id_fk": {
+          "name": "community_board_budget_request_agency_category_response_id_cbbr_agency_category_response_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "cbbr_agency_category_response",
+          "columnsFrom": [
+            "agency_category_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_policy_area_id_cbbr_policy_area_id_fk": {
+          "name": "community_board_budget_request_policy_area_id_cbbr_policy_area_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "cbbr_policy_area",
+          "columnsFrom": [
+            "policy_area_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_need_group_id_cbbr_need_group_id_fk": {
+          "name": "community_board_budget_request_need_group_id_cbbr_need_group_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "cbbr_need_group",
+          "columnsFrom": [
+            "need_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_need_id_cbbr_need_id_fk": {
+          "name": "community_board_budget_request_need_id_cbbr_need_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "cbbr_need",
+          "columnsFrom": [
+            "need_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_request_id_cbbr_request_id_fk": {
+          "name": "community_board_budget_request_request_id_cbbr_request_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "cbbr_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_board_budget_request_borough_id_community_district_id_community_district_borough_id_id_fk": {
+          "name": "community_board_budget_request_borough_id_community_district_id_community_district_borough_id_id_fk",
+          "tableFrom": "community_board_budget_request",
+          "tableTo": "community_district",
+          "columnsFrom": [
+            "borough_id",
+            "community_district_id"
+          ],
+          "columnsTo": [
+            "borough_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "community_board_budget_request_request_type_options": {
+          "name": "community_board_budget_request_request_type_options",
+          "value": "\"community_board_budget_request\".\"request_type\" IN (\n        'Capital',\n        'Expense'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.community_district": {
+      "name": "community_district",
+      "schema": "",
+      "columns": {
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_fill": {
+          "name": "mercator_fill",
+          "type": "geometry(multiPolygon,3857)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mercator_label": {
+          "name": "mercator_label",
+          "type": "geometry(point,3857)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "community_district_li_ft_index": {
+          "name": "community_district_li_ft_index",
+          "columns": [
+            {
+              "expression": "li_ft",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_fill_index": {
+          "name": "community_district_mercator_fill_index",
+          "columns": [
+            {
+              "expression": "mercator_fill",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        },
+        "community_district_mercator_label_index": {
+          "name": "community_district_mercator_label_index",
+          "columns": [
+            {
+              "expression": "mercator_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "GIST",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_district_borough_id_borough_id_fk": {
+          "name": "community_district_borough_id_borough_id_fk",
+          "tableFrom": "community_district",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "community_district_borough_id_id_pk": {
+          "name": "community_district_borough_id_id_pk",
+          "columns": [
+            "borough_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.land_use": {
+      "name": "land_use",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(2)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managing_code": {
+      "name": "managing_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(3)",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tax_lot": {
+      "name": "tax_lot",
+      "schema": "",
+      "columns": {
+        "bbl": {
+          "name": "bbl",
+          "type": "char(10)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "borough_id": {
+          "name": "borough_id",
+          "type": "char(1)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot": {
+          "name": "lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_use_id": {
+          "name": "land_use_id",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tax_lot_borough_id_borough_id_fk": {
+          "name": "tax_lot_borough_id_borough_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "borough",
+          "columnsFrom": [
+            "borough_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tax_lot_land_use_id_land_use_id_fk": {
+          "name": "tax_lot_land_use_id_land_use_id_fk",
+          "tableFrom": "tax_lot",
+          "tableTo": "land_use",
+          "columnsFrom": [
+            "land_use_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoning_district": {
+      "name": "zoning_district",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84": {
+          "name": "wgs84",
+          "type": "geography(multiPolygon, 4326)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "li_ft": {
+          "name": "li_ft",
+          "type": "geometry(multiPolygon,2263)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoning_district_class": {
+      "name": "zoning_district_class",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "char(9)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "zoning_district_class_category_options": {
+          "name": "zoning_district_class_category_options",
+          "value": "\"zoning_district_class\".\"category\" IN ('Residential', 'Commercial', 'Manufacturing')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.zoning_district_zoning_district_class": {
+      "name": "zoning_district_zoning_district_class",
+      "schema": "",
+      "columns": {
+        "zoning_district_id": {
+          "name": "zoning_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoning_district_class_id": {
+          "name": "zoning_district_class_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_id_zoning_district_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district",
+          "columnsFrom": [
+            "zoning_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk": {
+          "name": "zoning_district_zoning_district_class_zoning_district_class_id_zoning_district_class_id_fk",
+          "tableFrom": "zoning_district_zoning_district_class",
+          "tableTo": "zoning_district_class",
+          "columnsFrom": [
+            "zoning_district_class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migration/meta/_journal.json
+++ b/db/migration/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1763731910731,
       "tag": "0028_last_sersi",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1768248921775,
+      "tag": "0029_new_morlocks",
+      "breakpoints": true
     }
   ]
 }

--- a/src/borough/borough.repository.ts
+++ b/src/borough/borough.repository.ts
@@ -66,7 +66,13 @@ export class BoroughRepository {
 
   async findMany(): Promise<FindManyRepo> {
     try {
-      return await this.db.query.borough.findMany();
+      return await this.db.query.borough.findMany({
+        columns: {
+          id: true,
+          title: true,
+          abbr: true,
+        },
+      });
     } catch {
       throw new DataRetrievalException("cannot find boroughs");
     }

--- a/src/schema/borough.ts
+++ b/src/schema/borough.ts
@@ -1,10 +1,14 @@
 import { char, pgTable, text } from "drizzle-orm/pg-core";
+import { multiPolygonGeom, pointGeom } from "src/drizzle-pgis";
 import { z } from "zod";
 
 export const borough = pgTable("borough", {
   id: char("id", { length: 1 }).primaryKey(),
   title: text("title").notNull(),
   abbr: text("abbr").notNull(),
+  liFt: multiPolygonGeom("li_ft", 2263),
+  mercatorFill: multiPolygonGeom("mercator_fill", 3857),
+  mercatorLabel: pointGeom("mercator_label", 3857),
 });
 
 export const boroughIdEntitySchema = z.string().regex(/^[1-9]$/);


### PR DESCRIPTION
- Update borough table with spatial columns
- Update borough repository to return only non-spatial columns

closes #545

# Related
Is supported by: NYCPlanning/ae-data-flow#123
