### PR TITLE
617 CBBR tiles are showing Expense Requests

### DIFF
--- a/src/community-board-budget-request/community-board-budget-request.repository.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.ts
@@ -778,9 +778,12 @@ export class CommunityBoardBudgetRequestRepository {
           eq(communityBoardBudgetRequest.boroughId, borough.id),
         )
         .where(
-          or(
-            sql`${communityBoardBudgetRequest.mercatorFillMPnt} && ST_TileEnvelope(${z},${x},${y})`,
-            sql`${communityBoardBudgetRequest.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})`,
+          and(
+            or(
+              sql`${communityBoardBudgetRequest.mercatorFillMPnt} && ST_TileEnvelope(${z},${x},${y})`,
+              sql`${communityBoardBudgetRequest.mercatorFillMPoly} && ST_TileEnvelope(${z},${x},${y})`,
+            ),
+            eq(communityBoardBudgetRequest.requestType, "Capital"),
           ),
         )
         .as("tile");


### PR DESCRIPTION
CBBR tiles now only show Capital requests

Closes #617 

Fixes the bug in https://github.com/NYCPlanning/ae-cp-map/issues/475