### PR TITLE
Fix agencyCategoryResponse typo in CBBR schemas

### DIFF
--- a/src/borough/borough.repository.ts
+++ b/src/borough/borough.repository.ts
@@ -303,9 +303,9 @@ export class BoroughRepository {
           agencyInitials: sql`${communityBoardBudgetRequest.agency}`.as(
             "agencyInitials",
           ),
-          agencyCategoryReponseId:
+          agencyCategoryResponseId:
             sql`${communityBoardBudgetRequest.agencyCategoryResponse}`.as(
-              "agencyCategoryReponseId",
+              "agencyCategoryResponseId",
             ),
           communityBoardId:
             sql`${borough.abbr} || ${communityBoardBudgetRequest.communityDistrictId}`.as(

--- a/src/city-council-district/city-council-district.repository.ts
+++ b/src/city-council-district/city-council-district.repository.ts
@@ -248,9 +248,9 @@ export class CityCouncilDistrictRepository {
           agencyInitials: sql`${communityBoardBudgetRequest.agency}`.as(
             "agencyInitials",
           ),
-          agencyCategoryReponseId:
+          agencyCategoryResponseId:
             sql`${communityBoardBudgetRequest.agencyCategoryResponse}`.as(
-              "agencyCategoryReponseId",
+              "agencyCategoryResponseId",
             ),
           communityBoardId:
             sql`${borough.abbr} || ${communityBoardBudgetRequest.communityDistrictId}`.as(

--- a/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.schema.ts
@@ -64,7 +64,7 @@ export const communityBoardBudgetRequestRepoSchema =
       cbbrType: communityBoardBudgetRequestEntitySchema.shape.requestType,
       isMapped: z.boolean(),
       cbbrAgencyCategoryResponseId:
-        communityBoardBudgetRequestEntitySchema.shape.agencyCategoryReponse,
+        communityBoardBudgetRequestEntitySchema.shape.agencyCategoryResponse,
       cbbrAgencyResponse:
         communityBoardBudgetRequestEntitySchema.shape.agencyResponse,
     });

--- a/src/community-board-budget-request/community-board-budget-request.repository.ts
+++ b/src/community-board-budget-request/community-board-budget-request.repository.ts
@@ -793,9 +793,9 @@ export class CommunityBoardBudgetRequestRepository {
           agencyInitials: sql`${communityBoardBudgetRequest.agency}`.as(
             "agencyInitials",
           ),
-          agencyCategoryReponseId:
+          agencyCategoryResponseId:
             sql`${communityBoardBudgetRequest.agencyCategoryResponse}`.as(
-              "agencyCategoryReponseId",
+              "agencyCategoryResponseId",
             ),
           communityBoardId:
             sql`${borough.abbr} || ${communityBoardBudgetRequest.communityDistrictId}`.as(

--- a/src/schema/community-board-budget-request.schema.spec.ts
+++ b/src/schema/community-board-budget-request.schema.spec.ts
@@ -1,0 +1,24 @@
+import { communityBoardBudgetRequestEntitySchema } from "./community-board-budget-request";
+
+describe("communityBoardBudgetRequestEntitySchema", () => {
+  const agencyCategoryResponseSchema =
+    communityBoardBudgetRequestEntitySchema.pick({
+      agencyCategoryResponse: true,
+    });
+
+  it("accepts agencyCategoryResponse", () => {
+    const result = agencyCategoryResponseSchema.safeParse({
+      agencyCategoryResponse: 1,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects the legacy agencyCategoryReponse key", () => {
+    const result = agencyCategoryResponseSchema.safeParse({
+      agencyCategoryReponse: 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schema/community-board-budget-request.ts
+++ b/src/schema/community-board-budget-request.ts
@@ -192,7 +192,7 @@ export const communityBoardBudgetRequestEntitySchema = z.object({
   communityDistrictId: communityDistrictEntitySchema.shape.id,
   agency: agencyEntitySchema.shape.initials,
   managingCode: managingCodeEntitySchema.shape.id,
-  agencyCategoryReponse:
+  agencyCategoryResponse:
     cbbrAgencyCategoryResponseEntitySchema.shape.id.nullable(),
   agencyResponse: z.string().nullable(),
   requestType: cbbrRequestTypeEntitySchema,


### PR DESCRIPTION
This updates the misspelled agencyCategoryReponse key to agencyCategoryResponse where it is used in CBBR schema and tile query mappings.\n\nI also added a small schema spec that validates the corrected key and rejects the legacy misspelling.\n\nFixes #528