### PR TITLE
635, 650 Fixes

### DIFF
--- a/openapi/components/schemas/FacilityCategory.yaml
+++ b/openapi/components/schemas/FacilityCategory.yaml
@@ -1,10 +1,9 @@
 type: object
 properties:
   id:
-    type: string
-    pattern: ^([0-9]{1,3})$
+    type: integer
     description: The id for the category.
-    example: '1'
+    example: 1
   name:
     type: string
     description: The name of the category.

--- a/openapi/components/schemas/FacilityCategory.yaml
+++ b/openapi/components/schemas/FacilityCategory.yaml
@@ -9,10 +9,14 @@ properties:
     type: string
     description: The name of the category.
     example: Education, Child Welfare, and Youth
+  shortName:
+    type: string
+    description: The shortened name of the category.
+    example: Education, Youth
   description:
     type: string
     description: The description of the category.
-    example: Education, Youth
+    example: Providers of children and youth services and all schools, including higher education facilities
   groups:
     type: array
     items:
@@ -20,5 +24,6 @@ properties:
 required:
   - id
   - name
+  - shortName
   - description
   - groups

--- a/openapi/components/schemas/FacilityCategoryGroup.yaml
+++ b/openapi/components/schemas/FacilityCategoryGroup.yaml
@@ -1,10 +1,9 @@
 type: object
 properties:
   id:
-    type: string
-    pattern: ^([0-9]{1,3})$
+    type: integer
     description: The id for the group.
-    example: '1'
+    example: 1
   name:
     type: string
     description: The name of the group.

--- a/openapi/components/schemas/FacilityCategorySubgroup.yaml
+++ b/openapi/components/schemas/FacilityCategorySubgroup.yaml
@@ -1,10 +1,9 @@
 type: object
 properties:
   id:
-    type: string
-    pattern: ^([0-9]{1,3})$
+    type: integer
     description: The id for the subgroup.
-    example: '1'
+    example: 1
   name:
     type: string
     description: The name of the subgroup.

--- a/src/facility/facility.repository.ts
+++ b/src/facility/facility.repository.ts
@@ -452,6 +452,7 @@ export class FacilityRepository {
   async findCategories(): Promise<FindDomainRepo> {
     try {
       return await this.db.query.facilityDomain.findMany({
+        orderBy: (t) => sql`${t.id} asc`,
         with: {
           groups: {
             with: {

--- a/src/gen/schemas/facilityCategory.json
+++ b/src/gen/schemas/facilityCategory.json
@@ -2,10 +2,9 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string",
-      "pattern": "^([0-9]{1,3})$",
+      "type": "integer",
       "description": "The id for the category.",
-      "example": "1"
+      "example": 1
     },
     "name": {
       "type": "string",
@@ -28,10 +27,9 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^([0-9]{1,3})$",
+            "type": "integer",
             "description": "The id for the group.",
-            "example": "1"
+            "example": 1
           },
           "name": {
             "type": "string",
@@ -50,10 +48,9 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "string",
-                  "pattern": "^([0-9]{1,3})$",
+                  "type": "integer",
                   "description": "The id for the subgroup.",
-                  "example": "1"
+                  "example": 1
                 },
                 "name": {
                   "type": "string",

--- a/src/gen/schemas/facilityCategory.json
+++ b/src/gen/schemas/facilityCategory.json
@@ -12,10 +12,15 @@
       "description": "The name of the category.",
       "example": "Education, Child Welfare, and Youth"
     },
+    "shortName": {
+      "type": "string",
+      "description": "The shortened name of the category.",
+      "example": "Education, Youth"
+    },
     "description": {
       "type": "string",
       "description": "The description of the category.",
-      "example": "Education, Youth"
+      "example": "Providers of children and youth services and all schools, including higher education facilities"
     },
     "groups": {
       "type": "array",
@@ -71,6 +76,6 @@
       }
     }
   },
-  "required": ["id", "name", "description", "groups"],
+  "required": ["id", "name", "shortName", "description", "groups"],
   "x-readme-ref-name": "FacilityCategory"
 }

--- a/src/gen/schemas/facilityCategoryGroup.json
+++ b/src/gen/schemas/facilityCategoryGroup.json
@@ -2,10 +2,9 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string",
-      "pattern": "^([0-9]{1,3})$",
+      "type": "integer",
       "description": "The id for the group.",
-      "example": "1"
+      "example": 1
     },
     "name": {
       "type": "string",
@@ -24,10 +23,9 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "pattern": "^([0-9]{1,3})$",
+            "type": "integer",
             "description": "The id for the subgroup.",
-            "example": "1"
+            "example": 1
           },
           "name": {
             "type": "string",

--- a/src/gen/schemas/facilityCategorySubgroup.json
+++ b/src/gen/schemas/facilityCategorySubgroup.json
@@ -2,10 +2,9 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string",
-      "pattern": "^([0-9]{1,3})$",
+      "type": "integer",
       "description": "The id for the subgroup.",
-      "example": "1"
+      "example": 1
     },
     "name": {
       "type": "string",

--- a/src/gen/types/FacilityCategory.ts
+++ b/src/gen/types/FacilityCategory.ts
@@ -18,6 +18,11 @@ export type FacilityCategory = {
    */
   name: string;
   /**
+   * @description The shortened name of the category.
+   * @type string
+   */
+  shortName: string;
+  /**
    * @description The description of the category.
    * @type string
    */

--- a/src/gen/types/FacilityCategory.ts
+++ b/src/gen/types/FacilityCategory.ts
@@ -8,10 +8,9 @@ import type { FacilityCategoryGroup } from "./FacilityCategoryGroup";
 export type FacilityCategory = {
   /**
    * @description The id for the category.
-   * @pattern ^([0-9]{1,3})$
-   * @type string
+   * @type integer
    */
-  id: string;
+  id: number;
   /**
    * @description The name of the category.
    * @type string

--- a/src/gen/types/FacilityCategoryGroup.ts
+++ b/src/gen/types/FacilityCategoryGroup.ts
@@ -8,10 +8,9 @@ import type { FacilityCategorySubgroup } from "./FacilityCategorySubgroup";
 export type FacilityCategoryGroup = {
   /**
    * @description The id for the group.
-   * @pattern ^([0-9]{1,3})$
-   * @type string
+   * @type integer
    */
-  id: string;
+  id: number;
   /**
    * @description The name of the group.
    * @type string

--- a/src/gen/types/FacilityCategorySubgroup.ts
+++ b/src/gen/types/FacilityCategorySubgroup.ts
@@ -6,10 +6,9 @@
 export type FacilityCategorySubgroup = {
   /**
    * @description The id for the subgroup.
-   * @pattern ^([0-9]{1,3})$
-   * @type string
+   * @type integer
    */
-  id: string;
+  id: number;
   /**
    * @description The name of the subgroup.
    * @type string

--- a/src/gen/zod/facilityCategoryGroupSchema.ts
+++ b/src/gen/zod/facilityCategoryGroupSchema.ts
@@ -7,10 +7,7 @@ import { facilityCategorySubgroupSchema } from "./facilityCategorySubgroupSchema
 import { z } from "zod";
 
 export const facilityCategoryGroupSchema = z.object({
-  id: z
-    .string()
-    .regex(/^([0-9]{1,3})$/)
-    .describe("The id for the group."),
+  id: z.number().int().describe("The id for the group."),
   name: z.string().describe("The name of the group."),
   description: z.nullable(z.string().describe("The description of the group.")),
   subgroups: z.array(z.lazy(() => facilityCategorySubgroupSchema)),

--- a/src/gen/zod/facilityCategorySchema.ts
+++ b/src/gen/zod/facilityCategorySchema.ts
@@ -7,10 +7,7 @@ import { facilityCategoryGroupSchema } from "./facilityCategoryGroupSchema";
 import { z } from "zod";
 
 export const facilityCategorySchema = z.object({
-  id: z
-    .string()
-    .regex(/^([0-9]{1,3})$/)
-    .describe("The id for the category."),
+  id: z.number().int().describe("The id for the category."),
   name: z.string().describe("The name of the category."),
   shortName: z.string().describe("The shortened name of the category."),
   description: z.string().describe("The description of the category."),

--- a/src/gen/zod/facilityCategorySchema.ts
+++ b/src/gen/zod/facilityCategorySchema.ts
@@ -12,6 +12,7 @@ export const facilityCategorySchema = z.object({
     .regex(/^([0-9]{1,3})$/)
     .describe("The id for the category."),
   name: z.string().describe("The name of the category."),
+  shortName: z.string().describe("The shortened name of the category."),
   description: z.string().describe("The description of the category."),
   groups: z.array(z.lazy(() => facilityCategoryGroupSchema)),
 });

--- a/src/gen/zod/facilityCategorySubgroupSchema.ts
+++ b/src/gen/zod/facilityCategorySubgroupSchema.ts
@@ -6,10 +6,7 @@
 import { z } from "zod";
 
 export const facilityCategorySubgroupSchema = z.object({
-  id: z
-    .string()
-    .regex(/^([0-9]{1,3})$/)
-    .describe("The id for the subgroup."),
+  id: z.number().int().describe("The id for the subgroup."),
   name: z.string().describe("The name of the subgroup."),
   description: z.string().describe("The description of the subgroup."),
 });


### PR DESCRIPTION
This fixes a couple of issues:
#635 Orders the categories endpoint results by id
          Returns ids as integers instead of strings
#650 Updates the OpenAPI schema to add shortName to the categories endpoint